### PR TITLE
feat: Add support for auth:oauth2 tag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,19 +2,20 @@
   "targets": [
     {
       "target_name": "tree_sitter_bruno_binding",
+      "dependencies": [
+        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except",
+      ],
       "include_dirs": [
-        "<!(node -e \"require('nan')\")",
-        "src"
+        "src",
       ],
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
-        # If your language uses an external scanner, add it here.
-				"src/scanner.c",
+        "src/scanner.c",
       ],
       "cflags_c": [
         "-std=c99",
-      ]
+      ],
     }
   ]
 }

--- a/bindings/node/binding.cc
+++ b/bindings/node/binding.cc
@@ -1,28 +1,20 @@
-#include "tree_sitter/parser.h"
-#include <node.h>
-#include "nan.h"
+#include <napi.h>
 
-using namespace v8;
+typedef struct TSLanguage TSLanguage;
 
-extern "C" TSLanguage * tree_sitter_bruno();
+extern "C" TSLanguage *tree_sitter_bruno();
 
-namespace {
+// "tree-sitter", "language" hashed with BLAKE2
+const napi_type_tag LANGUAGE_TYPE_TAG = {
+  0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
+};
 
-NAN_METHOD(New) {}
-
-void Init(Local<Object> exports, Local<Object> module) {
-  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
-  tpl->SetClassName(Nan::New("Language").ToLocalChecked());
-  tpl->InstanceTemplate()->SetInternalFieldCount(1);
-
-  Local<Function> constructor = Nan::GetFunction(tpl).ToLocalChecked();
-  Local<Object> instance = constructor->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
-  Nan::SetInternalFieldPointer(instance, 0, tree_sitter_bruno());
-
-  Nan::Set(instance, Nan::New("name").ToLocalChecked(), Nan::New("bruno").ToLocalChecked());
-  Nan::Set(module, Nan::New("exports").ToLocalChecked(), instance);
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    exports["name"] = Napi::String::New(env, "bruno");
+    auto language = Napi::External<TSLanguage>::New(env, tree_sitter_bruno());
+    language.TypeTag(&LANGUAGE_TYPE_TAG);
+    exports["language"] = language;
+    return exports;
 }
 
-NODE_MODULE(tree_sitter_bruno_binding, Init)
-
-}  // namespace
+NODE_API_MODULE(tree_sitter_bruno_binding, Init)

--- a/grammar.js
+++ b/grammar.js
@@ -60,6 +60,7 @@ module.exports = grammar({
       $.authbasic,
       $.authbearer,
       $.authdigest,
+      $.authoauth2,
     ),
     authawsv4: $ => seq(
       alias("auth:awsv4", $.keyword),
@@ -75,6 +76,10 @@ module.exports = grammar({
     ),
     authdigest: $ => seq(
       alias("auth:digest", $.keyword),
+      $.dictionary,
+    ),
+    authoauth2: $ => seq(
+      alias("auth:oauth2", $.keyword),
       $.dictionary,
     ),
 
@@ -167,7 +172,7 @@ module.exports = grammar({
       alias("script:post-response", $.keyword),
       $.textblock,
     ),
-		
+
     tests: $ => seq(
 			alias("tests", $.keyword),
 			$.textblock

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Bruno grammar for tree-sitter",
   "main": "bindings/node",
+  "types": "bindings/node",
   "scripts": {
     "generate": "tree-sitter generate",
     "parse": "tree-sitter parse",
@@ -14,7 +15,7 @@
     "url": "git+https://github.com/Scalamando/tree-sitter-bruno.git"
   },
   "keywords": [
-		"bruno",
+    "bruno",
     "tree-sitter",
     "parser"
   ],
@@ -46,7 +47,7 @@
   },
   "homepage": "https://github.com/Scalamando/tree-sitter-bruno#readme",
   "dependencies": {
-    "nan": "^2.18.0"
+    "node-addon-api": "^7.1.0"
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.20.8"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -184,6 +184,10 @@
         {
           "type": "SYMBOL",
           "name": "authdigest"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "authoauth2"
         }
       ]
     },
@@ -249,6 +253,24 @@
           "content": {
             "type": "STRING",
             "value": "auth:digest"
+          },
+          "named": true,
+          "value": "keyword"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dictionary"
+        }
+      ]
+    },
+    "authoauth2": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "auth:oauth2"
           },
           "named": true,
           "value": "keyword"
@@ -841,4 +863,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -144,6 +144,25 @@
     }
   },
   {
+    "type": "authoauth2",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "dictionary",
+          "named": true
+        },
+        {
+          "type": "keyword",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "auths",
     "named": true,
     "fields": {},
@@ -165,6 +184,10 @@
         },
         {
           "type": "authdigest",
+          "named": true
+        },
+        {
+          "type": "authoauth2",
           "named": true
         }
       ]

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,22 +1,21 @@
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 
 #if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 91
+#define STATE_COUNT 93
 #define LARGE_STATE_COUNT 4
-#define SYMBOL_COUNT 89
+#define SYMBOL_COUNT 91
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 46
+#define TOKEN_COUNT 47
 #define EXTERNAL_TOKEN_COUNT 1
 #define FIELD_COUNT 1
 #define MAX_ALIAS_SEQUENCE_LENGTH 3
 #define PRODUCTION_ID_COUNT 4
 
-enum {
+enum ts_symbol_identifiers {
   anon_sym_meta = 1,
   anon_sym_get = 2,
   anon_sym_post = 3,
@@ -33,78 +32,80 @@ enum {
   anon_sym_auth_COLONbasic = 14,
   anon_sym_auth_COLONbearer = 15,
   anon_sym_auth_COLONdigest = 16,
-  anon_sym_body = 17,
-  anon_sym_body_COLONjson = 18,
-  anon_sym_body_COLONtext = 19,
-  anon_sym_body_COLONxml = 20,
-  anon_sym_body_COLONsparql = 21,
-  anon_sym_body_COLONgraphql = 22,
-  anon_sym_body_COLONgraphql_COLONvars = 23,
-  anon_sym_body_COLONform_DASHurlencoded = 24,
-  anon_sym_body_COLONmultipart_DASHform = 25,
-  anon_sym_vars = 26,
-  anon_sym_vars_COLONsecret = 27,
-  anon_sym_vars_COLONpre_DASHrequest = 28,
-  anon_sym_vars_COLONpost_DASHresponse = 29,
-  anon_sym_assert = 30,
-  anon_sym_script_COLONpre_DASHrequest = 31,
-  anon_sym_script_COLONpost_DASHresponse = 32,
-  anon_sym_tests = 33,
-  anon_sym_docs = 34,
-  anon_sym_LBRACE = 35,
-  anon_sym_RBRACE = 36,
-  anon_sym_LBRACK = 37,
-  anon_sym_COMMA = 38,
-  anon_sym_RBRACK = 39,
-  sym_array_value = 40,
-  anon_sym_COLON = 41,
-  sym_assert_key = 42,
-  sym_key = 43,
-  sym_value = 44,
-  sym_rawtext = 45,
-  sym_source_file = 46,
-  sym_meta = 47,
-  sym_http = 48,
-  sym_http_verb = 49,
-  sym_query = 50,
-  sym_headers = 51,
-  sym_auths = 52,
-  sym_authawsv4 = 53,
-  sym_authbasic = 54,
-  sym_authbearer = 55,
-  sym_authdigest = 56,
-  sym_bodies = 57,
-  sym_bodyforms = 58,
-  sym_body = 59,
-  sym_bodyjson = 60,
-  sym_bodytext = 61,
-  sym_bodyxml = 62,
-  sym_bodysparql = 63,
-  sym_bodygraphql = 64,
-  sym_bodygraphqlvars = 65,
-  sym_bodyformurlencoded = 66,
-  sym_bodyformmultipart = 67,
-  sym_varsandassert = 68,
-  sym_vars = 69,
-  sym_vars_secret = 70,
-  sym_varsreq = 71,
-  sym_varsres = 72,
-  sym_assert = 73,
-  sym_script = 74,
-  sym_scriptreq = 75,
-  sym_scriptres = 76,
-  sym_tests = 77,
-  sym_docs = 78,
-  sym_textblock = 79,
-  sym_array = 80,
-  sym_dictionary = 81,
-  sym_dictionary_pair = 82,
-  sym_assert_dictionary = 83,
-  sym_assert_dictionary_pair = 84,
-  aux_sym_source_file_repeat1 = 85,
-  aux_sym_array_repeat1 = 86,
-  aux_sym_dictionary_repeat1 = 87,
-  aux_sym_assert_dictionary_repeat1 = 88,
+  anon_sym_auth_COLONoauth2 = 17,
+  anon_sym_body = 18,
+  anon_sym_body_COLONjson = 19,
+  anon_sym_body_COLONtext = 20,
+  anon_sym_body_COLONxml = 21,
+  anon_sym_body_COLONsparql = 22,
+  anon_sym_body_COLONgraphql = 23,
+  anon_sym_body_COLONgraphql_COLONvars = 24,
+  anon_sym_body_COLONform_DASHurlencoded = 25,
+  anon_sym_body_COLONmultipart_DASHform = 26,
+  anon_sym_vars = 27,
+  anon_sym_vars_COLONsecret = 28,
+  anon_sym_vars_COLONpre_DASHrequest = 29,
+  anon_sym_vars_COLONpost_DASHresponse = 30,
+  anon_sym_assert = 31,
+  anon_sym_script_COLONpre_DASHrequest = 32,
+  anon_sym_script_COLONpost_DASHresponse = 33,
+  anon_sym_tests = 34,
+  anon_sym_docs = 35,
+  anon_sym_LBRACE = 36,
+  anon_sym_RBRACE = 37,
+  anon_sym_LBRACK = 38,
+  anon_sym_COMMA = 39,
+  anon_sym_RBRACK = 40,
+  sym_array_value = 41,
+  anon_sym_COLON = 42,
+  sym_assert_key = 43,
+  sym_key = 44,
+  sym_value = 45,
+  sym_rawtext = 46,
+  sym_source_file = 47,
+  sym_meta = 48,
+  sym_http = 49,
+  sym_http_verb = 50,
+  sym_query = 51,
+  sym_headers = 52,
+  sym_auths = 53,
+  sym_authawsv4 = 54,
+  sym_authbasic = 55,
+  sym_authbearer = 56,
+  sym_authdigest = 57,
+  sym_authoauth2 = 58,
+  sym_bodies = 59,
+  sym_bodyforms = 60,
+  sym_body = 61,
+  sym_bodyjson = 62,
+  sym_bodytext = 63,
+  sym_bodyxml = 64,
+  sym_bodysparql = 65,
+  sym_bodygraphql = 66,
+  sym_bodygraphqlvars = 67,
+  sym_bodyformurlencoded = 68,
+  sym_bodyformmultipart = 69,
+  sym_varsandassert = 70,
+  sym_vars = 71,
+  sym_vars_secret = 72,
+  sym_varsreq = 73,
+  sym_varsres = 74,
+  sym_assert = 75,
+  sym_script = 76,
+  sym_scriptreq = 77,
+  sym_scriptres = 78,
+  sym_tests = 79,
+  sym_docs = 80,
+  sym_textblock = 81,
+  sym_array = 82,
+  sym_dictionary = 83,
+  sym_dictionary_pair = 84,
+  sym_assert_dictionary = 85,
+  sym_assert_dictionary_pair = 86,
+  aux_sym_source_file_repeat1 = 87,
+  aux_sym_array_repeat1 = 88,
+  aux_sym_dictionary_repeat1 = 89,
+  aux_sym_assert_dictionary_repeat1 = 90,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -125,6 +126,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_auth_COLONbasic] = "keyword",
   [anon_sym_auth_COLONbearer] = "keyword",
   [anon_sym_auth_COLONdigest] = "keyword",
+  [anon_sym_auth_COLONoauth2] = "keyword",
   [anon_sym_body] = "keyword",
   [anon_sym_body_COLONjson] = "keyword",
   [anon_sym_body_COLONtext] = "keyword",
@@ -165,6 +167,7 @@ static const char * const ts_symbol_names[] = {
   [sym_authbasic] = "authbasic",
   [sym_authbearer] = "authbearer",
   [sym_authdigest] = "authdigest",
+  [sym_authoauth2] = "authoauth2",
   [sym_bodies] = "bodies",
   [sym_bodyforms] = "bodyforms",
   [sym_body] = "body",
@@ -217,6 +220,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_auth_COLONbasic] = anon_sym_meta,
   [anon_sym_auth_COLONbearer] = anon_sym_meta,
   [anon_sym_auth_COLONdigest] = anon_sym_meta,
+  [anon_sym_auth_COLONoauth2] = anon_sym_meta,
   [anon_sym_body] = anon_sym_meta,
   [anon_sym_body_COLONjson] = anon_sym_meta,
   [anon_sym_body_COLONtext] = anon_sym_meta,
@@ -257,6 +261,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_authbasic] = sym_authbasic,
   [sym_authbearer] = sym_authbearer,
   [sym_authdigest] = sym_authdigest,
+  [sym_authoauth2] = sym_authoauth2,
   [sym_bodies] = sym_bodies,
   [sym_bodyforms] = sym_bodyforms,
   [sym_body] = sym_body,
@@ -357,6 +362,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = true,
   },
   [anon_sym_auth_COLONdigest] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_auth_COLONoauth2] = {
     .visible = true,
     .named = true,
   },
@@ -520,6 +529,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_authoauth2] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_bodies] = {
     .visible = true,
     .named = true,
@@ -650,7 +663,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
 };
 
-enum {
+enum ts_field_identifiers {
   field_tag = 1,
 };
 
@@ -775,6 +788,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [88] = 88,
   [89] = 89,
   [90] = 90,
+  [91] = 91,
+  [92] = 92,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -782,831 +797,846 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(190);
+      if (eof) ADVANCE(195);
       if (lookahead == '\n') SKIP(0)
       if (lookahead == '\r') SKIP(0)
-      if (lookahead == ',') ADVANCE(230);
-      if (lookahead == ':') ADVANCE(233);
-      if (lookahead == '[') ADVANCE(229);
-      if (lookahead == ']') ADVANCE(231);
-      if (lookahead == 'a') ADVANCE(136);
-      if (lookahead == 'b') ADVANCE(93);
-      if (lookahead == 'c') ADVANCE(94);
-      if (lookahead == 'd') ADVANCE(38);
-      if (lookahead == 'g') ADVANCE(46);
-      if (lookahead == 'h') ADVANCE(45);
-      if (lookahead == 'm') ADVANCE(48);
-      if (lookahead == 'o') ADVANCE(106);
-      if (lookahead == 'p') ADVANCE(20);
-      if (lookahead == 'q') ADVANCE(180);
-      if (lookahead == 's') ADVANCE(26);
-      if (lookahead == 't') ADVANCE(59);
-      if (lookahead == 'v') ADVANCE(17);
-      if (lookahead == '{') ADVANCE(225);
-      if (lookahead == '}') ADVANCE(226);
-      if (lookahead == '\t' ||
+      if (lookahead == ',') ADVANCE(236);
+      if (lookahead == ':') ADVANCE(239);
+      if (lookahead == '[') ADVANCE(235);
+      if (lookahead == ']') ADVANCE(237);
+      if (lookahead == 'a') ADVANCE(139);
+      if (lookahead == 'b') ADVANCE(96);
+      if (lookahead == 'c') ADVANCE(97);
+      if (lookahead == 'd') ADVANCE(40);
+      if (lookahead == 'g') ADVANCE(48);
+      if (lookahead == 'h') ADVANCE(47);
+      if (lookahead == 'm') ADVANCE(50);
+      if (lookahead == 'o') ADVANCE(108);
+      if (lookahead == 'p') ADVANCE(22);
+      if (lookahead == 'q') ADVANCE(184);
+      if (lookahead == 's') ADVANCE(28);
+      if (lookahead == 't') ADVANCE(61);
+      if (lookahead == 'v') ADVANCE(18);
+      if (lookahead == '{') ADVANCE(231);
+      if (lookahead == '}') ADVANCE(232);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') SKIP(0)
       END_STATE();
     case 1:
       if (lookahead == '\n') SKIP(1)
       if (lookahead == '\r') SKIP(1)
-      if (lookahead == '}') ADVANCE(227);
-      if (lookahead == '\t' ||
+      if (lookahead == '}') ADVANCE(233);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') SKIP(1)
       if (lookahead != 0 &&
-          lookahead != ':') ADVANCE(236);
+          lookahead != ':') ADVANCE(242);
       END_STATE();
     case 2:
       if (lookahead == '\n') SKIP(2)
       if (lookahead == '\r') SKIP(2)
-      if (lookahead == '}') ADVANCE(228);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(234);
+      if (lookahead == '}') ADVANCE(234);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') ADVANCE(240);
       if (lookahead != 0 &&
-          lookahead != ':') ADVANCE(235);
+          lookahead != ':') ADVANCE(241);
       END_STATE();
     case 3:
       if (lookahead == '\n') SKIP(3)
       if (lookahead == '\r') SKIP(3)
-      if (lookahead == ',') ADVANCE(230);
-      if (lookahead == ']') ADVANCE(231);
-      if (lookahead == '\t' ||
+      if (lookahead == ',') ADVANCE(236);
+      if (lookahead == ']') ADVANCE(237);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') SKIP(3)
       if (lookahead != 0 &&
-          lookahead != '[') ADVANCE(232);
+          lookahead != '[') ADVANCE(238);
       END_STATE();
     case 4:
       if (lookahead == '\n') SKIP(4)
       if (lookahead == '\r') SKIP(4)
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(237);
-      if (lookahead != 0) ADVANCE(238);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') ADVANCE(243);
+      if (lookahead != 0) ADVANCE(244);
       END_STATE();
     case 5:
-      if (lookahead == '-') ADVANCE(67);
+      if (lookahead == '-') ADVANCE(69);
       END_STATE();
     case 6:
-      if (lookahead == '-') ADVANCE(181);
+      if (lookahead == '-') ADVANCE(185);
       END_STATE();
     case 7:
-      if (lookahead == '-') ADVANCE(128);
+      if (lookahead == '-') ADVANCE(131);
       END_STATE();
     case 8:
-      if (lookahead == '-') ADVANCE(129);
+      if (lookahead == '-') ADVANCE(132);
       END_STATE();
     case 9:
-      if (lookahead == '-') ADVANCE(134);
+      if (lookahead == '-') ADVANCE(137);
       END_STATE();
     case 10:
-      if (lookahead == '-') ADVANCE(135);
+      if (lookahead == '-') ADVANCE(138);
       END_STATE();
     case 11:
-      if (lookahead == '4') ADVANCE(203);
+      if (lookahead == '2') ADVANCE(212);
       END_STATE();
     case 12:
-      if (lookahead == ':') ADVANCE(15);
+      if (lookahead == '4') ADVANCE(208);
       END_STATE();
     case 13:
-      if (lookahead == ':') ADVANCE(112);
+      if (lookahead == ':') ADVANCE(16);
       END_STATE();
     case 14:
-      if (lookahead == 'a') ADVANCE(191);
+      if (lookahead == ':') ADVANCE(115);
       END_STATE();
     case 15:
-      if (lookahead == 'a') ADVANCE(186);
-      if (lookahead == 'b') ADVANCE(23);
-      if (lookahead == 'd') ADVANCE(72);
+      if (lookahead == 'a') ADVANCE(196);
       END_STATE();
     case 16:
-      if (lookahead == 'a') ADVANCE(35);
+      if (lookahead == 'a') ADVANCE(191);
+      if (lookahead == 'b') ADVANCE(25);
+      if (lookahead == 'd') ADVANCE(75);
+      if (lookahead == 'o') ADVANCE(19);
       END_STATE();
     case 17:
-      if (lookahead == 'a') ADVANCE(123);
+      if (lookahead == 'a') ADVANCE(37);
       END_STATE();
     case 18:
-      if (lookahead == 'a') ADVANCE(105);
+      if (lookahead == 'a') ADVANCE(126);
       END_STATE();
     case 19:
-      if (lookahead == 'a') ADVANCE(30);
+      if (lookahead == 'a') ADVANCE(186);
       END_STATE();
     case 20:
-      if (lookahead == 'a') ADVANCE(171);
-      if (lookahead == 'o') ADVANCE(146);
-      if (lookahead == 'u') ADVANCE(161);
+      if (lookahead == 'a') ADVANCE(109);
       END_STATE();
     case 21:
-      if (lookahead == 'a') ADVANCE(132);
+      if (lookahead == 'a') ADVANCE(32);
       END_STATE();
     case 22:
-      if (lookahead == 'a') ADVANCE(117);
+      if (lookahead == 'a') ADVANCE(174);
+      if (lookahead == 'o') ADVANCE(149);
+      if (lookahead == 'u') ADVANCE(164);
       END_STATE();
     case 23:
-      if (lookahead == 'a') ADVANCE(144);
-      if (lookahead == 'e') ADVANCE(21);
+      if (lookahead == 'a') ADVANCE(135);
       END_STATE();
     case 24:
-      if (lookahead == 'a') ADVANCE(131);
+      if (lookahead == 'a') ADVANCE(120);
       END_STATE();
     case 25:
-      if (lookahead == 'a') ADVANCE(130);
+      if (lookahead == 'a') ADVANCE(147);
+      if (lookahead == 'e') ADVANCE(23);
       END_STATE();
     case 26:
-      if (lookahead == 'c') ADVANCE(120);
+      if (lookahead == 'a') ADVANCE(134);
       END_STATE();
     case 27:
-      if (lookahead == 'c') ADVANCE(204);
+      if (lookahead == 'a') ADVANCE(133);
       END_STATE();
     case 28:
-      if (lookahead == 'c') ADVANCE(70);
+      if (lookahead == 'c') ADVANCE(123);
       END_STATE();
     case 29:
-      if (lookahead == 'c') ADVANCE(137);
+      if (lookahead == 'c') ADVANCE(209);
       END_STATE();
     case 30:
-      if (lookahead == 'c') ADVANCE(39);
+      if (lookahead == 'c') ADVANCE(72);
       END_STATE();
     case 31:
-      if (lookahead == 'c') ADVANCE(133);
+      if (lookahead == 'c') ADVANCE(140);
       END_STATE();
     case 32:
-      if (lookahead == 'c') ADVANCE(164);
+      if (lookahead == 'c') ADVANCE(41);
       END_STATE();
     case 33:
-      if (lookahead == 'c') ADVANCE(95);
+      if (lookahead == 'c') ADVANCE(136);
       END_STATE();
     case 34:
-      if (lookahead == 'd') ADVANCE(188);
+      if (lookahead == 'c') ADVANCE(167);
       END_STATE();
     case 35:
-      if (lookahead == 'd') ADVANCE(198);
+      if (lookahead == 'c') ADVANCE(98);
       END_STATE();
     case 36:
-      if (lookahead == 'd') ADVANCE(214);
+      if (lookahead == 'd') ADVANCE(193);
       END_STATE();
     case 37:
-      if (lookahead == 'd') ADVANCE(50);
+      if (lookahead == 'd') ADVANCE(203);
       END_STATE();
     case 38:
-      if (lookahead == 'e') ADVANCE(82);
-      if (lookahead == 'o') ADVANCE(29);
+      if (lookahead == 'd') ADVANCE(220);
       END_STATE();
     case 39:
-      if (lookahead == 'e') ADVANCE(200);
+      if (lookahead == 'd') ADVANCE(52);
       END_STATE();
     case 40:
-      if (lookahead == 'e') ADVANCE(195);
+      if (lookahead == 'e') ADVANCE(85);
+      if (lookahead == 'o') ADVANCE(31);
       END_STATE();
     case 41:
-      if (lookahead == 'e') ADVANCE(187);
+      if (lookahead == 'e') ADVANCE(205);
       END_STATE();
     case 42:
-      if (lookahead == 'e') ADVANCE(7);
+      if (lookahead == 'e') ADVANCE(200);
       END_STATE();
     case 43:
-      if (lookahead == 'e') ADVANCE(219);
+      if (lookahead == 'e') ADVANCE(192);
       END_STATE();
     case 44:
-      if (lookahead == 'e') ADVANCE(222);
+      if (lookahead == 'e') ADVANCE(7);
       END_STATE();
     case 45:
-      if (lookahead == 'e') ADVANCE(16);
+      if (lookahead == 'e') ADVANCE(225);
       END_STATE();
     case 46:
-      if (lookahead == 'e') ADVANCE(159);
+      if (lookahead == 'e') ADVANCE(228);
       END_STATE();
     case 47:
-      if (lookahead == 'e') ADVANCE(115);
+      if (lookahead == 'e') ADVANCE(17);
       END_STATE();
     case 48:
-      if (lookahead == 'e') ADVANCE(173);
+      if (lookahead == 'e') ADVANCE(162);
       END_STATE();
     case 49:
-      if (lookahead == 'e') ADVANCE(119);
-      END_STATE();
-    case 50:
-      if (lookahead == 'e') ADVANCE(36);
-      END_STATE();
-    case 51:
-      if (lookahead == 'e') ADVANCE(127);
-      END_STATE();
-    case 52:
-      if (lookahead == 'e') ADVANCE(32);
-      END_STATE();
-    case 53:
-      if (lookahead == 'e') ADVANCE(89);
-      END_STATE();
-    case 54:
-      if (lookahead == 'e') ADVANCE(176);
-      END_STATE();
-    case 55:
-      if (lookahead == 'e') ADVANCE(145);
-      END_STATE();
-    case 56:
       if (lookahead == 'e') ADVANCE(118);
       END_STATE();
+    case 50:
+      if (lookahead == 'e') ADVANCE(177);
+      END_STATE();
+    case 51:
+      if (lookahead == 'e') ADVANCE(122);
+      END_STATE();
+    case 52:
+      if (lookahead == 'e') ADVANCE(38);
+      END_STATE();
+    case 53:
+      if (lookahead == 'e') ADVANCE(130);
+      END_STATE();
+    case 54:
+      if (lookahead == 'e') ADVANCE(34);
+      END_STATE();
+    case 55:
+      if (lookahead == 'e') ADVANCE(92);
+      END_STATE();
+    case 56:
+      if (lookahead == 'e') ADVANCE(180);
+      END_STATE();
     case 57:
-      if (lookahead == 'e') ADVANCE(167);
+      if (lookahead == 'e') ADVANCE(148);
       END_STATE();
     case 58:
-      if (lookahead == 'e') ADVANCE(31);
+      if (lookahead == 'e') ADVANCE(121);
       END_STATE();
     case 59:
-      if (lookahead == 'e') ADVANCE(147);
-      if (lookahead == 'r') ADVANCE(19);
+      if (lookahead == 'e') ADVANCE(170);
       END_STATE();
     case 60:
-      if (lookahead == 'e') ADVANCE(151);
+      if (lookahead == 'e') ADVANCE(33);
       END_STATE();
     case 61:
-      if (lookahead == 'e') ADVANCE(152);
+      if (lookahead == 'e') ADVANCE(150);
+      if (lookahead == 'r') ADVANCE(21);
       END_STATE();
     case 62:
-      if (lookahead == 'e') ADVANCE(153);
+      if (lookahead == 'e') ADVANCE(154);
       END_STATE();
     case 63:
-      if (lookahead == 'e') ADVANCE(156);
+      if (lookahead == 'e') ADVANCE(155);
       END_STATE();
     case 64:
-      if (lookahead == 'e') ADVANCE(116);
+      if (lookahead == 'e') ADVANCE(156);
       END_STATE();
     case 65:
-      if (lookahead == 'e') ADVANCE(10);
+      if (lookahead == 'e') ADVANCE(159);
       END_STATE();
     case 66:
-      if (lookahead == 'f') ADVANCE(99);
-      if (lookahead == 'g') ADVANCE(124);
-      if (lookahead == 'j') ADVANCE(154);
-      if (lookahead == 'm') ADVANCE(179);
-      if (lookahead == 's') ADVANCE(108);
-      if (lookahead == 't') ADVANCE(41);
-      if (lookahead == 'x') ADVANCE(85);
+      if (lookahead == 'e') ADVANCE(119);
       END_STATE();
     case 67:
-      if (lookahead == 'f') ADVANCE(100);
+      if (lookahead == 'e') ADVANCE(10);
       END_STATE();
     case 68:
-      if (lookahead == 'g') ADVANCE(60);
+      if (lookahead == 'f') ADVANCE(102);
+      if (lookahead == 'g') ADVANCE(127);
+      if (lookahead == 'j') ADVANCE(157);
+      if (lookahead == 'm') ADVANCE(183);
+      if (lookahead == 's') ADVANCE(111);
+      if (lookahead == 't') ADVANCE(43);
+      if (lookahead == 'x') ADVANCE(88);
       END_STATE();
     case 69:
-      if (lookahead == 'h') ADVANCE(12);
+      if (lookahead == 'f') ADVANCE(103);
       END_STATE();
     case 70:
-      if (lookahead == 'h') ADVANCE(196);
+      if (lookahead == 'g') ADVANCE(62);
       END_STATE();
     case 71:
-      if (lookahead == 'h') ADVANCE(114);
+      if (lookahead == 'h') ADVANCE(13);
       END_STATE();
     case 72:
-      if (lookahead == 'i') ADVANCE(68);
+      if (lookahead == 'h') ADVANCE(201);
       END_STATE();
     case 73:
-      if (lookahead == 'i') ADVANCE(96);
+      if (lookahead == 'h') ADVANCE(11);
       END_STATE();
     case 74:
-      if (lookahead == 'i') ADVANCE(27);
+      if (lookahead == 'h') ADVANCE(117);
       END_STATE();
     case 75:
-      if (lookahead == 'i') ADVANCE(107);
+      if (lookahead == 'i') ADVANCE(70);
       END_STATE();
     case 76:
-      if (lookahead == 'i') ADVANCE(110);
+      if (lookahead == 'i') ADVANCE(99);
       END_STATE();
     case 77:
-      if (lookahead == 'l') ADVANCE(210);
+      if (lookahead == 'i') ADVANCE(29);
       END_STATE();
     case 78:
-      if (lookahead == 'l') ADVANCE(211);
+      if (lookahead == 'i') ADVANCE(110);
       END_STATE();
     case 79:
-      if (lookahead == 'l') ADVANCE(212);
+      if (lookahead == 'i') ADVANCE(113);
       END_STATE();
     case 80:
-      if (lookahead == 'l') ADVANCE(53);
+      if (lookahead == 'l') ADVANCE(216);
       END_STATE();
     case 81:
-      if (lookahead == 'l') ADVANCE(175);
+      if (lookahead == 'l') ADVANCE(217);
       END_STATE();
     case 82:
-      if (lookahead == 'l') ADVANCE(54);
+      if (lookahead == 'l') ADVANCE(218);
       END_STATE();
     case 83:
-      if (lookahead == 'm') ADVANCE(215);
+      if (lookahead == 'l') ADVANCE(55);
       END_STATE();
     case 84:
-      if (lookahead == 'm') ADVANCE(6);
+      if (lookahead == 'l') ADVANCE(179);
       END_STATE();
     case 85:
-      if (lookahead == 'm') ADVANCE(77);
+      if (lookahead == 'l') ADVANCE(56);
       END_STATE();
     case 86:
-      if (lookahead == 'n') ADVANCE(208);
+      if (lookahead == 'm') ADVANCE(221);
       END_STATE();
     case 87:
-      if (lookahead == 'n') ADVANCE(88);
+      if (lookahead == 'm') ADVANCE(6);
       END_STATE();
     case 88:
-      if (lookahead == 'n') ADVANCE(52);
+      if (lookahead == 'm') ADVANCE(80);
       END_STATE();
     case 89:
-      if (lookahead == 'n') ADVANCE(33);
+      if (lookahead == 'n') ADVANCE(214);
       END_STATE();
     case 90:
-      if (lookahead == 'n') ADVANCE(141);
+      if (lookahead == 'n') ADVANCE(91);
       END_STATE();
     case 91:
-      if (lookahead == 'n') ADVANCE(148);
+      if (lookahead == 'n') ADVANCE(54);
       END_STATE();
     case 92:
-      if (lookahead == 'n') ADVANCE(150);
+      if (lookahead == 'n') ADVANCE(35);
       END_STATE();
     case 93:
-      if (lookahead == 'o') ADVANCE(34);
+      if (lookahead == 'n') ADVANCE(144);
       END_STATE();
     case 94:
-      if (lookahead == 'o') ADVANCE(87);
+      if (lookahead == 'n') ADVANCE(151);
       END_STATE();
     case 95:
-      if (lookahead == 'o') ADVANCE(37);
+      if (lookahead == 'n') ADVANCE(153);
       END_STATE();
     case 96:
-      if (lookahead == 'o') ADVANCE(90);
+      if (lookahead == 'o') ADVANCE(36);
       END_STATE();
     case 97:
-      if (lookahead == 'o') ADVANCE(86);
+      if (lookahead == 'o') ADVANCE(90);
       END_STATE();
     case 98:
-      if (lookahead == 'o') ADVANCE(91);
+      if (lookahead == 'o') ADVANCE(39);
       END_STATE();
     case 99:
-      if (lookahead == 'o') ADVANCE(121);
+      if (lookahead == 'o') ADVANCE(93);
       END_STATE();
     case 100:
-      if (lookahead == 'o') ADVANCE(122);
+      if (lookahead == 'o') ADVANCE(89);
       END_STATE();
     case 101:
-      if (lookahead == 'o') ADVANCE(149);
-      if (lookahead == 'r') ADVANCE(42);
+      if (lookahead == 'o') ADVANCE(94);
       END_STATE();
     case 102:
-      if (lookahead == 'o') ADVANCE(92);
+      if (lookahead == 'o') ADVANCE(124);
       END_STATE();
     case 103:
-      if (lookahead == 'o') ADVANCE(157);
-      if (lookahead == 'r') ADVANCE(65);
+      if (lookahead == 'o') ADVANCE(125);
       END_STATE();
     case 104:
-      if (lookahead == 'p') ADVANCE(101);
-      if (lookahead == 's') ADVANCE(58);
+      if (lookahead == 'o') ADVANCE(152);
+      if (lookahead == 'r') ADVANCE(44);
       END_STATE();
     case 105:
-      if (lookahead == 'p') ADVANCE(71);
+      if (lookahead == 'o') ADVANCE(95);
       END_STATE();
     case 106:
-      if (lookahead == 'p') ADVANCE(160);
+      if (lookahead == 'o') ADVANCE(160);
+      if (lookahead == 'r') ADVANCE(67);
       END_STATE();
     case 107:
-      if (lookahead == 'p') ADVANCE(170);
+      if (lookahead == 'p') ADVANCE(104);
+      if (lookahead == 's') ADVANCE(60);
       END_STATE();
     case 108:
-      if (lookahead == 'p') ADVANCE(22);
+      if (lookahead == 'p') ADVANCE(163);
       END_STATE();
     case 109:
-      if (lookahead == 'p') ADVANCE(98);
+      if (lookahead == 'p') ADVANCE(74);
       END_STATE();
     case 110:
-      if (lookahead == 'p') ADVANCE(24);
+      if (lookahead == 'p') ADVANCE(173);
       END_STATE();
     case 111:
-      if (lookahead == 'p') ADVANCE(102);
+      if (lookahead == 'p') ADVANCE(24);
       END_STATE();
     case 112:
-      if (lookahead == 'p') ADVANCE(103);
+      if (lookahead == 'p') ADVANCE(101);
       END_STATE();
     case 113:
-      if (lookahead == 'q') ADVANCE(78);
+      if (lookahead == 'p') ADVANCE(26);
       END_STATE();
     case 114:
-      if (lookahead == 'q') ADVANCE(79);
+      if (lookahead == 'p') ADVANCE(105);
       END_STATE();
     case 115:
-      if (lookahead == 'q') ADVANCE(182);
+      if (lookahead == 'p') ADVANCE(106);
       END_STATE();
     case 116:
-      if (lookahead == 'q') ADVANCE(183);
+      if (lookahead == 'q') ADVANCE(81);
       END_STATE();
     case 117:
-      if (lookahead == 'r') ADVANCE(113);
+      if (lookahead == 'q') ADVANCE(82);
       END_STATE();
     case 118:
-      if (lookahead == 'r') ADVANCE(205);
+      if (lookahead == 'q') ADVANCE(187);
       END_STATE();
     case 119:
-      if (lookahead == 'r') ADVANCE(189);
+      if (lookahead == 'q') ADVANCE(188);
       END_STATE();
     case 120:
-      if (lookahead == 'r') ADVANCE(75);
+      if (lookahead == 'r') ADVANCE(116);
       END_STATE();
     case 121:
-      if (lookahead == 'r') ADVANCE(84);
+      if (lookahead == 'r') ADVANCE(210);
       END_STATE();
     case 122:
-      if (lookahead == 'r') ADVANCE(83);
+      if (lookahead == 'r') ADVANCE(194);
       END_STATE();
     case 123:
-      if (lookahead == 'r') ADVANCE(138);
+      if (lookahead == 'r') ADVANCE(78);
       END_STATE();
     case 124:
-      if (lookahead == 'r') ADVANCE(18);
+      if (lookahead == 'r') ADVANCE(87);
       END_STATE();
     case 125:
-      if (lookahead == 'r') ADVANCE(80);
+      if (lookahead == 'r') ADVANCE(86);
       END_STATE();
     case 126:
-      if (lookahead == 'r') ADVANCE(140);
+      if (lookahead == 'r') ADVANCE(141);
       END_STATE();
     case 127:
-      if (lookahead == 'r') ADVANCE(163);
+      if (lookahead == 'r') ADVANCE(20);
       END_STATE();
     case 128:
-      if (lookahead == 'r') ADVANCE(47);
+      if (lookahead == 'r') ADVANCE(83);
       END_STATE();
     case 129:
-      if (lookahead == 'r') ADVANCE(55);
-      END_STATE();
-    case 130:
       if (lookahead == 'r') ADVANCE(143);
       END_STATE();
+    case 130:
+      if (lookahead == 'r') ADVANCE(166);
+      END_STATE();
     case 131:
-      if (lookahead == 'r') ADVANCE(172);
+      if (lookahead == 'r') ADVANCE(49);
       END_STATE();
     case 132:
-      if (lookahead == 'r') ADVANCE(56);
-      END_STATE();
-    case 133:
       if (lookahead == 'r') ADVANCE(57);
       END_STATE();
+    case 133:
+      if (lookahead == 'r') ADVANCE(146);
+      END_STATE();
     case 134:
-      if (lookahead == 'r') ADVANCE(63);
+      if (lookahead == 'r') ADVANCE(176);
       END_STATE();
     case 135:
-      if (lookahead == 'r') ADVANCE(64);
+      if (lookahead == 'r') ADVANCE(58);
       END_STATE();
     case 136:
-      if (lookahead == 's') ADVANCE(155);
-      if (lookahead == 'u') ADVANCE(158);
+      if (lookahead == 'r') ADVANCE(59);
       END_STATE();
     case 137:
-      if (lookahead == 's') ADVANCE(224);
+      if (lookahead == 'r') ADVANCE(65);
       END_STATE();
     case 138:
-      if (lookahead == 's') ADVANCE(216);
+      if (lookahead == 'r') ADVANCE(66);
       END_STATE();
     case 139:
-      if (lookahead == 's') ADVANCE(223);
+      if (lookahead == 's') ADVANCE(158);
+      if (lookahead == 'u') ADVANCE(161);
       END_STATE();
     case 140:
-      if (lookahead == 's') ADVANCE(202);
+      if (lookahead == 's') ADVANCE(230);
       END_STATE();
     case 141:
-      if (lookahead == 's') ADVANCE(197);
+      if (lookahead == 's') ADVANCE(222);
       END_STATE();
     case 142:
-      if (lookahead == 's') ADVANCE(184);
+      if (lookahead == 's') ADVANCE(229);
       END_STATE();
     case 143:
-      if (lookahead == 's') ADVANCE(213);
+      if (lookahead == 's') ADVANCE(207);
       END_STATE();
     case 144:
-      if (lookahead == 's') ADVANCE(74);
+      if (lookahead == 's') ADVANCE(202);
       END_STATE();
     case 145:
-      if (lookahead == 's') ADVANCE(109);
+      if (lookahead == 's') ADVANCE(189);
       END_STATE();
     case 146:
-      if (lookahead == 's') ADVANCE(162);
+      if (lookahead == 's') ADVANCE(219);
       END_STATE();
     case 147:
-      if (lookahead == 's') ADVANCE(174);
+      if (lookahead == 's') ADVANCE(77);
       END_STATE();
     case 148:
-      if (lookahead == 's') ADVANCE(43);
+      if (lookahead == 's') ADVANCE(112);
       END_STATE();
     case 149:
-      if (lookahead == 's') ADVANCE(177);
+      if (lookahead == 's') ADVANCE(165);
       END_STATE();
     case 150:
-      if (lookahead == 's') ADVANCE(44);
-      END_STATE();
-    case 151:
-      if (lookahead == 's') ADVANCE(166);
-      END_STATE();
-    case 152:
-      if (lookahead == 's') ADVANCE(168);
-      END_STATE();
-    case 153:
-      if (lookahead == 's') ADVANCE(169);
-      END_STATE();
-    case 154:
-      if (lookahead == 's') ADVANCE(97);
-      END_STATE();
-    case 155:
-      if (lookahead == 's') ADVANCE(51);
-      END_STATE();
-    case 156:
-      if (lookahead == 's') ADVANCE(111);
-      END_STATE();
-    case 157:
       if (lookahead == 's') ADVANCE(178);
       END_STATE();
+    case 151:
+      if (lookahead == 's') ADVANCE(45);
+      END_STATE();
+    case 152:
+      if (lookahead == 's') ADVANCE(181);
+      END_STATE();
+    case 153:
+      if (lookahead == 's') ADVANCE(46);
+      END_STATE();
+    case 154:
+      if (lookahead == 's') ADVANCE(169);
+      END_STATE();
+    case 155:
+      if (lookahead == 's') ADVANCE(171);
+      END_STATE();
+    case 156:
+      if (lookahead == 's') ADVANCE(172);
+      END_STATE();
+    case 157:
+      if (lookahead == 's') ADVANCE(100);
+      END_STATE();
     case 158:
-      if (lookahead == 't') ADVANCE(69);
+      if (lookahead == 's') ADVANCE(53);
       END_STATE();
     case 159:
-      if (lookahead == 't') ADVANCE(192);
+      if (lookahead == 's') ADVANCE(114);
       END_STATE();
     case 160:
-      if (lookahead == 't') ADVANCE(73);
+      if (lookahead == 's') ADVANCE(182);
       END_STATE();
     case 161:
-      if (lookahead == 't') ADVANCE(194);
+      if (lookahead == 't') ADVANCE(71);
       END_STATE();
     case 162:
-      if (lookahead == 't') ADVANCE(193);
+      if (lookahead == 't') ADVANCE(197);
       END_STATE();
     case 163:
-      if (lookahead == 't') ADVANCE(220);
+      if (lookahead == 't') ADVANCE(76);
       END_STATE();
     case 164:
       if (lookahead == 't') ADVANCE(199);
       END_STATE();
     case 165:
-      if (lookahead == 't') ADVANCE(209);
+      if (lookahead == 't') ADVANCE(198);
       END_STATE();
     case 166:
-      if (lookahead == 't') ADVANCE(206);
+      if (lookahead == 't') ADVANCE(226);
       END_STATE();
     case 167:
-      if (lookahead == 't') ADVANCE(217);
+      if (lookahead == 't') ADVANCE(204);
       END_STATE();
     case 168:
-      if (lookahead == 't') ADVANCE(218);
+      if (lookahead == 't') ADVANCE(215);
       END_STATE();
     case 169:
-      if (lookahead == 't') ADVANCE(221);
+      if (lookahead == 't') ADVANCE(211);
       END_STATE();
     case 170:
-      if (lookahead == 't') ADVANCE(13);
+      if (lookahead == 't') ADVANCE(223);
       END_STATE();
     case 171:
-      if (lookahead == 't') ADVANCE(28);
+      if (lookahead == 't') ADVANCE(224);
       END_STATE();
     case 172:
-      if (lookahead == 't') ADVANCE(5);
+      if (lookahead == 't') ADVANCE(227);
       END_STATE();
     case 173:
       if (lookahead == 't') ADVANCE(14);
       END_STATE();
     case 174:
-      if (lookahead == 't') ADVANCE(139);
+      if (lookahead == 't') ADVANCE(30);
       END_STATE();
     case 175:
-      if (lookahead == 't') ADVANCE(76);
+      if (lookahead == 't') ADVANCE(73);
       END_STATE();
     case 176:
-      if (lookahead == 't') ADVANCE(40);
+      if (lookahead == 't') ADVANCE(5);
       END_STATE();
     case 177:
-      if (lookahead == 't') ADVANCE(8);
+      if (lookahead == 't') ADVANCE(15);
       END_STATE();
     case 178:
-      if (lookahead == 't') ADVANCE(9);
+      if (lookahead == 't') ADVANCE(142);
       END_STATE();
     case 179:
-      if (lookahead == 'u') ADVANCE(81);
+      if (lookahead == 't') ADVANCE(79);
       END_STATE();
     case 180:
-      if (lookahead == 'u') ADVANCE(49);
+      if (lookahead == 't') ADVANCE(42);
       END_STATE();
     case 181:
-      if (lookahead == 'u') ADVANCE(125);
+      if (lookahead == 't') ADVANCE(8);
       END_STATE();
     case 182:
-      if (lookahead == 'u') ADVANCE(61);
+      if (lookahead == 't') ADVANCE(9);
       END_STATE();
     case 183:
-      if (lookahead == 'u') ADVANCE(62);
+      if (lookahead == 'u') ADVANCE(84);
       END_STATE();
     case 184:
-      if (lookahead == 'v') ADVANCE(11);
+      if (lookahead == 'u') ADVANCE(51);
       END_STATE();
     case 185:
-      if (lookahead == 'v') ADVANCE(25);
+      if (lookahead == 'u') ADVANCE(128);
       END_STATE();
     case 186:
-      if (lookahead == 'w') ADVANCE(142);
+      if (lookahead == 'u') ADVANCE(175);
       END_STATE();
     case 187:
-      if (lookahead == 'x') ADVANCE(165);
+      if (lookahead == 'u') ADVANCE(63);
       END_STATE();
     case 188:
-      if (lookahead == 'y') ADVANCE(207);
+      if (lookahead == 'u') ADVANCE(64);
       END_STATE();
     case 189:
-      if (lookahead == 'y') ADVANCE(201);
+      if (lookahead == 'v') ADVANCE(12);
       END_STATE();
     case 190:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (lookahead == 'v') ADVANCE(27);
       END_STATE();
     case 191:
-      ACCEPT_TOKEN(anon_sym_meta);
+      if (lookahead == 'w') ADVANCE(145);
       END_STATE();
     case 192:
-      ACCEPT_TOKEN(anon_sym_get);
+      if (lookahead == 'x') ADVANCE(168);
       END_STATE();
     case 193:
-      ACCEPT_TOKEN(anon_sym_post);
+      if (lookahead == 'y') ADVANCE(213);
       END_STATE();
     case 194:
-      ACCEPT_TOKEN(anon_sym_put);
+      if (lookahead == 'y') ADVANCE(206);
       END_STATE();
     case 195:
-      ACCEPT_TOKEN(anon_sym_delete);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 196:
-      ACCEPT_TOKEN(anon_sym_patch);
+      ACCEPT_TOKEN(anon_sym_meta);
       END_STATE();
     case 197:
-      ACCEPT_TOKEN(anon_sym_options);
+      ACCEPT_TOKEN(anon_sym_get);
       END_STATE();
     case 198:
-      ACCEPT_TOKEN(anon_sym_head);
-      if (lookahead == 'e') ADVANCE(126);
+      ACCEPT_TOKEN(anon_sym_post);
       END_STATE();
     case 199:
-      ACCEPT_TOKEN(anon_sym_connect);
+      ACCEPT_TOKEN(anon_sym_put);
       END_STATE();
     case 200:
-      ACCEPT_TOKEN(anon_sym_trace);
+      ACCEPT_TOKEN(anon_sym_delete);
       END_STATE();
     case 201:
-      ACCEPT_TOKEN(anon_sym_query);
+      ACCEPT_TOKEN(anon_sym_patch);
       END_STATE();
     case 202:
-      ACCEPT_TOKEN(anon_sym_headers);
+      ACCEPT_TOKEN(anon_sym_options);
       END_STATE();
     case 203:
-      ACCEPT_TOKEN(anon_sym_auth_COLONawsv4);
+      ACCEPT_TOKEN(anon_sym_head);
+      if (lookahead == 'e') ADVANCE(129);
       END_STATE();
     case 204:
-      ACCEPT_TOKEN(anon_sym_auth_COLONbasic);
+      ACCEPT_TOKEN(anon_sym_connect);
       END_STATE();
     case 205:
-      ACCEPT_TOKEN(anon_sym_auth_COLONbearer);
+      ACCEPT_TOKEN(anon_sym_trace);
       END_STATE();
     case 206:
-      ACCEPT_TOKEN(anon_sym_auth_COLONdigest);
+      ACCEPT_TOKEN(anon_sym_query);
       END_STATE();
     case 207:
-      ACCEPT_TOKEN(anon_sym_body);
-      if (lookahead == ':') ADVANCE(66);
+      ACCEPT_TOKEN(anon_sym_headers);
       END_STATE();
     case 208:
-      ACCEPT_TOKEN(anon_sym_body_COLONjson);
+      ACCEPT_TOKEN(anon_sym_auth_COLONawsv4);
       END_STATE();
     case 209:
-      ACCEPT_TOKEN(anon_sym_body_COLONtext);
+      ACCEPT_TOKEN(anon_sym_auth_COLONbasic);
       END_STATE();
     case 210:
-      ACCEPT_TOKEN(anon_sym_body_COLONxml);
+      ACCEPT_TOKEN(anon_sym_auth_COLONbearer);
       END_STATE();
     case 211:
-      ACCEPT_TOKEN(anon_sym_body_COLONsparql);
+      ACCEPT_TOKEN(anon_sym_auth_COLONdigest);
       END_STATE();
     case 212:
-      ACCEPT_TOKEN(anon_sym_body_COLONgraphql);
-      if (lookahead == ':') ADVANCE(185);
+      ACCEPT_TOKEN(anon_sym_auth_COLONoauth2);
       END_STATE();
     case 213:
-      ACCEPT_TOKEN(anon_sym_body_COLONgraphql_COLONvars);
+      ACCEPT_TOKEN(anon_sym_body);
+      if (lookahead == ':') ADVANCE(68);
       END_STATE();
     case 214:
-      ACCEPT_TOKEN(anon_sym_body_COLONform_DASHurlencoded);
+      ACCEPT_TOKEN(anon_sym_body_COLONjson);
       END_STATE();
     case 215:
-      ACCEPT_TOKEN(anon_sym_body_COLONmultipart_DASHform);
+      ACCEPT_TOKEN(anon_sym_body_COLONtext);
       END_STATE();
     case 216:
-      ACCEPT_TOKEN(anon_sym_vars);
-      if (lookahead == ':') ADVANCE(104);
+      ACCEPT_TOKEN(anon_sym_body_COLONxml);
       END_STATE();
     case 217:
-      ACCEPT_TOKEN(anon_sym_vars_COLONsecret);
+      ACCEPT_TOKEN(anon_sym_body_COLONsparql);
       END_STATE();
     case 218:
-      ACCEPT_TOKEN(anon_sym_vars_COLONpre_DASHrequest);
+      ACCEPT_TOKEN(anon_sym_body_COLONgraphql);
+      if (lookahead == ':') ADVANCE(190);
       END_STATE();
     case 219:
-      ACCEPT_TOKEN(anon_sym_vars_COLONpost_DASHresponse);
+      ACCEPT_TOKEN(anon_sym_body_COLONgraphql_COLONvars);
       END_STATE();
     case 220:
-      ACCEPT_TOKEN(anon_sym_assert);
+      ACCEPT_TOKEN(anon_sym_body_COLONform_DASHurlencoded);
       END_STATE();
     case 221:
-      ACCEPT_TOKEN(anon_sym_script_COLONpre_DASHrequest);
+      ACCEPT_TOKEN(anon_sym_body_COLONmultipart_DASHform);
       END_STATE();
     case 222:
-      ACCEPT_TOKEN(anon_sym_script_COLONpost_DASHresponse);
+      ACCEPT_TOKEN(anon_sym_vars);
+      if (lookahead == ':') ADVANCE(107);
       END_STATE();
     case 223:
-      ACCEPT_TOKEN(anon_sym_tests);
+      ACCEPT_TOKEN(anon_sym_vars_COLONsecret);
       END_STATE();
     case 224:
-      ACCEPT_TOKEN(anon_sym_docs);
+      ACCEPT_TOKEN(anon_sym_vars_COLONpre_DASHrequest);
       END_STATE();
     case 225:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      ACCEPT_TOKEN(anon_sym_vars_COLONpost_DASHresponse);
       END_STATE();
     case 226:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(anon_sym_assert);
       END_STATE();
     case 227:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ' &&
-          lookahead != ':') ADVANCE(236);
+      ACCEPT_TOKEN(anon_sym_script_COLONpre_DASHrequest);
       END_STATE();
     case 228:
+      ACCEPT_TOKEN(anon_sym_script_COLONpost_DASHresponse);
+      END_STATE();
+    case 229:
+      ACCEPT_TOKEN(anon_sym_tests);
+      END_STATE();
+    case 230:
+      ACCEPT_TOKEN(anon_sym_docs);
+      END_STATE();
+    case 231:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      END_STATE();
+    case 232:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 233:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != ' ' &&
+          lookahead != ':') ADVANCE(242);
+      END_STATE();
+    case 234:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ':') ADVANCE(235);
+          lookahead != ':') ADVANCE(241);
       END_STATE();
-    case 229:
+    case 235:
       ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
-    case 230:
+    case 236:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
-    case 231:
+    case 237:
       ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
-    case 232:
+    case 238:
       ACCEPT_TOKEN(sym_array_value);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
+          (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
           lookahead != ',' &&
           lookahead != '[' &&
-          lookahead != ']') ADVANCE(232);
+          lookahead != ']') ADVANCE(238);
       END_STATE();
-    case 233:
+    case 239:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 234:
+    case 240:
       ACCEPT_TOKEN(sym_assert_key);
-      if (lookahead == '}') ADVANCE(228);
+      if (lookahead == '}') ADVANCE(234);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(234);
+          lookahead == 11 ||
+          lookahead == '\f' ||
+          lookahead == ' ') ADVANCE(240);
       if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ':') ADVANCE(235);
+          (lookahead < '\n' || '\r' < lookahead) &&
+          lookahead != ':') ADVANCE(241);
       END_STATE();
-    case 235:
+    case 241:
       ACCEPT_TOKEN(sym_assert_key);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ':') ADVANCE(235);
+          lookahead != ':') ADVANCE(241);
       END_STATE();
-    case 236:
+    case 242:
       ACCEPT_TOKEN(sym_key);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
+          (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          lookahead != ':') ADVANCE(236);
+          lookahead != ':') ADVANCE(242);
       END_STATE();
-    case 237:
+    case 243:
       ACCEPT_TOKEN(sym_value);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(237);
+          lookahead == 11 ||
+          lookahead == '\f' ||
+          lookahead == ' ') ADVANCE(243);
       if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(238);
+          (lookahead < '\n' || '\r' < lookahead)) ADVANCE(244);
       END_STATE();
-    case 238:
+    case 244:
       ACCEPT_TOKEN(sym_value);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(238);
+          lookahead != '\r') ADVANCE(244);
       END_STATE();
     default:
       return false;
@@ -1658,34 +1688,34 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [41] = {.lex_state = 0},
   [42] = {.lex_state = 0},
   [43] = {.lex_state = 0},
-  [44] = {.lex_state = 1},
-  [45] = {.lex_state = 2},
-  [46] = {.lex_state = 1},
-  [47] = {.lex_state = 2},
-  [48] = {.lex_state = 1},
-  [49] = {.lex_state = 2},
-  [50] = {.lex_state = 3},
+  [44] = {.lex_state = 0},
+  [45] = {.lex_state = 1},
+  [46] = {.lex_state = 2},
+  [47] = {.lex_state = 1},
+  [48] = {.lex_state = 2},
+  [49] = {.lex_state = 1},
+  [50] = {.lex_state = 2},
   [51] = {.lex_state = 3},
   [52] = {.lex_state = 3},
   [53] = {.lex_state = 3},
-  [54] = {.lex_state = 0},
+  [54] = {.lex_state = 3},
   [55] = {.lex_state = 0},
   [56] = {.lex_state = 0},
-  [57] = {.lex_state = 0, .external_lex_state = 1},
+  [57] = {.lex_state = 0},
   [58] = {.lex_state = 0},
-  [59] = {.lex_state = 0},
-  [60] = {.lex_state = 2},
+  [59] = {.lex_state = 0, .external_lex_state = 1},
+  [60] = {.lex_state = 0},
   [61] = {.lex_state = 0},
   [62] = {.lex_state = 0},
   [63] = {.lex_state = 0},
   [64] = {.lex_state = 0},
   [65] = {.lex_state = 0},
   [66] = {.lex_state = 0},
-  [67] = {.lex_state = 1},
+  [67] = {.lex_state = 0},
   [68] = {.lex_state = 0},
-  [69] = {.lex_state = 0},
+  [69] = {.lex_state = 2},
   [70] = {.lex_state = 0},
-  [71] = {.lex_state = 0},
+  [71] = {.lex_state = 1},
   [72] = {.lex_state = 0},
   [73] = {.lex_state = 0},
   [74] = {.lex_state = 0},
@@ -1697,28 +1727,16 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [80] = {.lex_state = 0},
   [81] = {.lex_state = 0},
   [82] = {.lex_state = 0},
-  [83] = {.lex_state = 3},
-  [84] = {.lex_state = 4},
-  [85] = {.lex_state = 0},
+  [83] = {.lex_state = 0},
+  [84] = {.lex_state = 0},
+  [85] = {.lex_state = 3},
   [86] = {.lex_state = 4},
   [87] = {.lex_state = 0},
-  [88] = {.lex_state = 0},
+  [88] = {.lex_state = 4},
   [89] = {.lex_state = 0},
   [90] = {.lex_state = 0},
-};
-
-enum {
-  ts_external_token_rawtext = 0,
-};
-
-static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
-  [ts_external_token_rawtext] = sym_rawtext,
-};
-
-static const bool ts_external_scanner_states[2][EXTERNAL_TOKEN_COUNT] = {
-  [1] = {
-    [ts_external_token_rawtext] = true,
-  },
+  [91] = {.lex_state = 0},
+  [92] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1740,6 +1758,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_auth_COLONbasic] = ACTIONS(1),
     [anon_sym_auth_COLONbearer] = ACTIONS(1),
     [anon_sym_auth_COLONdigest] = ACTIONS(1),
+    [anon_sym_auth_COLONoauth2] = ACTIONS(1),
     [anon_sym_body] = ACTIONS(1),
     [anon_sym_body_COLONjson] = ACTIONS(1),
     [anon_sym_body_COLONtext] = ACTIONS(1),
@@ -1767,39 +1786,40 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_rawtext] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(90),
-    [sym_meta] = STATE(5),
-    [sym_http] = STATE(5),
-    [sym_http_verb] = STATE(59),
-    [sym_query] = STATE(5),
-    [sym_headers] = STATE(5),
-    [sym_auths] = STATE(5),
-    [sym_authawsv4] = STATE(31),
-    [sym_authbasic] = STATE(31),
-    [sym_authbearer] = STATE(31),
-    [sym_authdigest] = STATE(31),
-    [sym_bodies] = STATE(5),
-    [sym_bodyforms] = STATE(32),
-    [sym_body] = STATE(32),
-    [sym_bodyjson] = STATE(32),
-    [sym_bodytext] = STATE(32),
-    [sym_bodyxml] = STATE(32),
-    [sym_bodysparql] = STATE(32),
-    [sym_bodygraphql] = STATE(32),
-    [sym_bodygraphqlvars] = STATE(32),
-    [sym_bodyformurlencoded] = STATE(33),
-    [sym_bodyformmultipart] = STATE(33),
-    [sym_varsandassert] = STATE(5),
-    [sym_vars] = STATE(34),
-    [sym_vars_secret] = STATE(34),
-    [sym_varsreq] = STATE(34),
-    [sym_varsres] = STATE(34),
-    [sym_assert] = STATE(34),
-    [sym_script] = STATE(5),
-    [sym_scriptreq] = STATE(35),
-    [sym_scriptres] = STATE(35),
-    [sym_tests] = STATE(5),
-    [sym_docs] = STATE(5),
+    [sym_source_file] = STATE(89),
+    [sym_meta] = STATE(30),
+    [sym_http] = STATE(30),
+    [sym_http_verb] = STATE(61),
+    [sym_query] = STATE(30),
+    [sym_headers] = STATE(30),
+    [sym_auths] = STATE(30),
+    [sym_authawsv4] = STATE(32),
+    [sym_authbasic] = STATE(32),
+    [sym_authbearer] = STATE(32),
+    [sym_authdigest] = STATE(32),
+    [sym_authoauth2] = STATE(32),
+    [sym_bodies] = STATE(30),
+    [sym_bodyforms] = STATE(19),
+    [sym_body] = STATE(19),
+    [sym_bodyjson] = STATE(19),
+    [sym_bodytext] = STATE(19),
+    [sym_bodyxml] = STATE(19),
+    [sym_bodysparql] = STATE(19),
+    [sym_bodygraphql] = STATE(19),
+    [sym_bodygraphqlvars] = STATE(19),
+    [sym_bodyformurlencoded] = STATE(34),
+    [sym_bodyformmultipart] = STATE(34),
+    [sym_varsandassert] = STATE(30),
+    [sym_vars] = STATE(35),
+    [sym_vars_secret] = STATE(35),
+    [sym_varsreq] = STATE(35),
+    [sym_varsres] = STATE(35),
+    [sym_assert] = STATE(35),
+    [sym_script] = STATE(30),
+    [sym_scriptreq] = STATE(36),
+    [sym_scriptres] = STATE(36),
+    [sym_tests] = STATE(30),
+    [sym_docs] = STATE(30),
     [aux_sym_source_file_repeat1] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(3),
     [anon_sym_meta] = ACTIONS(5),
@@ -1818,60 +1838,62 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_auth_COLONbasic] = ACTIONS(17),
     [anon_sym_auth_COLONbearer] = ACTIONS(19),
     [anon_sym_auth_COLONdigest] = ACTIONS(21),
-    [anon_sym_body] = ACTIONS(23),
-    [anon_sym_body_COLONjson] = ACTIONS(25),
-    [anon_sym_body_COLONtext] = ACTIONS(27),
-    [anon_sym_body_COLONxml] = ACTIONS(29),
-    [anon_sym_body_COLONsparql] = ACTIONS(31),
-    [anon_sym_body_COLONgraphql] = ACTIONS(33),
-    [anon_sym_body_COLONgraphql_COLONvars] = ACTIONS(35),
-    [anon_sym_body_COLONform_DASHurlencoded] = ACTIONS(37),
-    [anon_sym_body_COLONmultipart_DASHform] = ACTIONS(39),
-    [anon_sym_vars] = ACTIONS(41),
-    [anon_sym_vars_COLONsecret] = ACTIONS(43),
-    [anon_sym_vars_COLONpre_DASHrequest] = ACTIONS(45),
-    [anon_sym_vars_COLONpost_DASHresponse] = ACTIONS(47),
-    [anon_sym_assert] = ACTIONS(49),
-    [anon_sym_script_COLONpre_DASHrequest] = ACTIONS(51),
-    [anon_sym_script_COLONpost_DASHresponse] = ACTIONS(53),
-    [anon_sym_tests] = ACTIONS(55),
-    [anon_sym_docs] = ACTIONS(57),
+    [anon_sym_auth_COLONoauth2] = ACTIONS(23),
+    [anon_sym_body] = ACTIONS(25),
+    [anon_sym_body_COLONjson] = ACTIONS(27),
+    [anon_sym_body_COLONtext] = ACTIONS(29),
+    [anon_sym_body_COLONxml] = ACTIONS(31),
+    [anon_sym_body_COLONsparql] = ACTIONS(33),
+    [anon_sym_body_COLONgraphql] = ACTIONS(35),
+    [anon_sym_body_COLONgraphql_COLONvars] = ACTIONS(37),
+    [anon_sym_body_COLONform_DASHurlencoded] = ACTIONS(39),
+    [anon_sym_body_COLONmultipart_DASHform] = ACTIONS(41),
+    [anon_sym_vars] = ACTIONS(43),
+    [anon_sym_vars_COLONsecret] = ACTIONS(45),
+    [anon_sym_vars_COLONpre_DASHrequest] = ACTIONS(47),
+    [anon_sym_vars_COLONpost_DASHresponse] = ACTIONS(49),
+    [anon_sym_assert] = ACTIONS(51),
+    [anon_sym_script_COLONpre_DASHrequest] = ACTIONS(53),
+    [anon_sym_script_COLONpost_DASHresponse] = ACTIONS(55),
+    [anon_sym_tests] = ACTIONS(57),
+    [anon_sym_docs] = ACTIONS(59),
   },
   [2] = {
-    [sym_meta] = STATE(5),
-    [sym_http] = STATE(5),
-    [sym_http_verb] = STATE(59),
-    [sym_query] = STATE(5),
-    [sym_headers] = STATE(5),
-    [sym_auths] = STATE(5),
-    [sym_authawsv4] = STATE(31),
-    [sym_authbasic] = STATE(31),
-    [sym_authbearer] = STATE(31),
-    [sym_authdigest] = STATE(31),
-    [sym_bodies] = STATE(5),
-    [sym_bodyforms] = STATE(32),
-    [sym_body] = STATE(32),
-    [sym_bodyjson] = STATE(32),
-    [sym_bodytext] = STATE(32),
-    [sym_bodyxml] = STATE(32),
-    [sym_bodysparql] = STATE(32),
-    [sym_bodygraphql] = STATE(32),
-    [sym_bodygraphqlvars] = STATE(32),
-    [sym_bodyformurlencoded] = STATE(33),
-    [sym_bodyformmultipart] = STATE(33),
-    [sym_varsandassert] = STATE(5),
-    [sym_vars] = STATE(34),
-    [sym_vars_secret] = STATE(34),
-    [sym_varsreq] = STATE(34),
-    [sym_varsres] = STATE(34),
-    [sym_assert] = STATE(34),
-    [sym_script] = STATE(5),
-    [sym_scriptreq] = STATE(35),
-    [sym_scriptres] = STATE(35),
-    [sym_tests] = STATE(5),
-    [sym_docs] = STATE(5),
+    [sym_meta] = STATE(30),
+    [sym_http] = STATE(30),
+    [sym_http_verb] = STATE(61),
+    [sym_query] = STATE(30),
+    [sym_headers] = STATE(30),
+    [sym_auths] = STATE(30),
+    [sym_authawsv4] = STATE(32),
+    [sym_authbasic] = STATE(32),
+    [sym_authbearer] = STATE(32),
+    [sym_authdigest] = STATE(32),
+    [sym_authoauth2] = STATE(32),
+    [sym_bodies] = STATE(30),
+    [sym_bodyforms] = STATE(19),
+    [sym_body] = STATE(19),
+    [sym_bodyjson] = STATE(19),
+    [sym_bodytext] = STATE(19),
+    [sym_bodyxml] = STATE(19),
+    [sym_bodysparql] = STATE(19),
+    [sym_bodygraphql] = STATE(19),
+    [sym_bodygraphqlvars] = STATE(19),
+    [sym_bodyformurlencoded] = STATE(34),
+    [sym_bodyformmultipart] = STATE(34),
+    [sym_varsandassert] = STATE(30),
+    [sym_vars] = STATE(35),
+    [sym_vars_secret] = STATE(35),
+    [sym_varsreq] = STATE(35),
+    [sym_varsres] = STATE(35),
+    [sym_assert] = STATE(35),
+    [sym_script] = STATE(30),
+    [sym_scriptreq] = STATE(36),
+    [sym_scriptres] = STATE(36),
+    [sym_tests] = STATE(30),
+    [sym_docs] = STATE(30),
     [aux_sym_source_file_repeat1] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(59),
+    [ts_builtin_sym_end] = ACTIONS(61),
     [anon_sym_meta] = ACTIONS(5),
     [anon_sym_get] = ACTIONS(7),
     [anon_sym_post] = ACTIONS(7),
@@ -1888,105 +1910,108 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_auth_COLONbasic] = ACTIONS(17),
     [anon_sym_auth_COLONbearer] = ACTIONS(19),
     [anon_sym_auth_COLONdigest] = ACTIONS(21),
-    [anon_sym_body] = ACTIONS(23),
-    [anon_sym_body_COLONjson] = ACTIONS(25),
-    [anon_sym_body_COLONtext] = ACTIONS(27),
-    [anon_sym_body_COLONxml] = ACTIONS(29),
-    [anon_sym_body_COLONsparql] = ACTIONS(31),
-    [anon_sym_body_COLONgraphql] = ACTIONS(33),
-    [anon_sym_body_COLONgraphql_COLONvars] = ACTIONS(35),
-    [anon_sym_body_COLONform_DASHurlencoded] = ACTIONS(37),
-    [anon_sym_body_COLONmultipart_DASHform] = ACTIONS(39),
-    [anon_sym_vars] = ACTIONS(41),
-    [anon_sym_vars_COLONsecret] = ACTIONS(43),
-    [anon_sym_vars_COLONpre_DASHrequest] = ACTIONS(45),
-    [anon_sym_vars_COLONpost_DASHresponse] = ACTIONS(47),
-    [anon_sym_assert] = ACTIONS(49),
-    [anon_sym_script_COLONpre_DASHrequest] = ACTIONS(51),
-    [anon_sym_script_COLONpost_DASHresponse] = ACTIONS(53),
-    [anon_sym_tests] = ACTIONS(55),
-    [anon_sym_docs] = ACTIONS(57),
+    [anon_sym_auth_COLONoauth2] = ACTIONS(23),
+    [anon_sym_body] = ACTIONS(25),
+    [anon_sym_body_COLONjson] = ACTIONS(27),
+    [anon_sym_body_COLONtext] = ACTIONS(29),
+    [anon_sym_body_COLONxml] = ACTIONS(31),
+    [anon_sym_body_COLONsparql] = ACTIONS(33),
+    [anon_sym_body_COLONgraphql] = ACTIONS(35),
+    [anon_sym_body_COLONgraphql_COLONvars] = ACTIONS(37),
+    [anon_sym_body_COLONform_DASHurlencoded] = ACTIONS(39),
+    [anon_sym_body_COLONmultipart_DASHform] = ACTIONS(41),
+    [anon_sym_vars] = ACTIONS(43),
+    [anon_sym_vars_COLONsecret] = ACTIONS(45),
+    [anon_sym_vars_COLONpre_DASHrequest] = ACTIONS(47),
+    [anon_sym_vars_COLONpost_DASHresponse] = ACTIONS(49),
+    [anon_sym_assert] = ACTIONS(51),
+    [anon_sym_script_COLONpre_DASHrequest] = ACTIONS(53),
+    [anon_sym_script_COLONpost_DASHresponse] = ACTIONS(55),
+    [anon_sym_tests] = ACTIONS(57),
+    [anon_sym_docs] = ACTIONS(59),
   },
   [3] = {
-    [sym_meta] = STATE(5),
-    [sym_http] = STATE(5),
-    [sym_http_verb] = STATE(59),
-    [sym_query] = STATE(5),
-    [sym_headers] = STATE(5),
-    [sym_auths] = STATE(5),
-    [sym_authawsv4] = STATE(31),
-    [sym_authbasic] = STATE(31),
-    [sym_authbearer] = STATE(31),
-    [sym_authdigest] = STATE(31),
-    [sym_bodies] = STATE(5),
-    [sym_bodyforms] = STATE(32),
-    [sym_body] = STATE(32),
-    [sym_bodyjson] = STATE(32),
-    [sym_bodytext] = STATE(32),
-    [sym_bodyxml] = STATE(32),
-    [sym_bodysparql] = STATE(32),
-    [sym_bodygraphql] = STATE(32),
-    [sym_bodygraphqlvars] = STATE(32),
-    [sym_bodyformurlencoded] = STATE(33),
-    [sym_bodyformmultipart] = STATE(33),
-    [sym_varsandassert] = STATE(5),
-    [sym_vars] = STATE(34),
-    [sym_vars_secret] = STATE(34),
-    [sym_varsreq] = STATE(34),
-    [sym_varsres] = STATE(34),
-    [sym_assert] = STATE(34),
-    [sym_script] = STATE(5),
-    [sym_scriptreq] = STATE(35),
-    [sym_scriptres] = STATE(35),
-    [sym_tests] = STATE(5),
-    [sym_docs] = STATE(5),
+    [sym_meta] = STATE(30),
+    [sym_http] = STATE(30),
+    [sym_http_verb] = STATE(61),
+    [sym_query] = STATE(30),
+    [sym_headers] = STATE(30),
+    [sym_auths] = STATE(30),
+    [sym_authawsv4] = STATE(32),
+    [sym_authbasic] = STATE(32),
+    [sym_authbearer] = STATE(32),
+    [sym_authdigest] = STATE(32),
+    [sym_authoauth2] = STATE(32),
+    [sym_bodies] = STATE(30),
+    [sym_bodyforms] = STATE(19),
+    [sym_body] = STATE(19),
+    [sym_bodyjson] = STATE(19),
+    [sym_bodytext] = STATE(19),
+    [sym_bodyxml] = STATE(19),
+    [sym_bodysparql] = STATE(19),
+    [sym_bodygraphql] = STATE(19),
+    [sym_bodygraphqlvars] = STATE(19),
+    [sym_bodyformurlencoded] = STATE(34),
+    [sym_bodyformmultipart] = STATE(34),
+    [sym_varsandassert] = STATE(30),
+    [sym_vars] = STATE(35),
+    [sym_vars_secret] = STATE(35),
+    [sym_varsreq] = STATE(35),
+    [sym_varsres] = STATE(35),
+    [sym_assert] = STATE(35),
+    [sym_script] = STATE(30),
+    [sym_scriptreq] = STATE(36),
+    [sym_scriptres] = STATE(36),
+    [sym_tests] = STATE(30),
+    [sym_docs] = STATE(30),
     [aux_sym_source_file_repeat1] = STATE(3),
-    [ts_builtin_sym_end] = ACTIONS(61),
-    [anon_sym_meta] = ACTIONS(63),
-    [anon_sym_get] = ACTIONS(66),
-    [anon_sym_post] = ACTIONS(66),
-    [anon_sym_put] = ACTIONS(66),
-    [anon_sym_delete] = ACTIONS(66),
-    [anon_sym_patch] = ACTIONS(66),
-    [anon_sym_options] = ACTIONS(66),
-    [anon_sym_head] = ACTIONS(69),
-    [anon_sym_connect] = ACTIONS(66),
-    [anon_sym_trace] = ACTIONS(66),
-    [anon_sym_query] = ACTIONS(72),
-    [anon_sym_headers] = ACTIONS(75),
-    [anon_sym_auth_COLONawsv4] = ACTIONS(78),
-    [anon_sym_auth_COLONbasic] = ACTIONS(81),
-    [anon_sym_auth_COLONbearer] = ACTIONS(84),
-    [anon_sym_auth_COLONdigest] = ACTIONS(87),
-    [anon_sym_body] = ACTIONS(90),
-    [anon_sym_body_COLONjson] = ACTIONS(93),
-    [anon_sym_body_COLONtext] = ACTIONS(96),
-    [anon_sym_body_COLONxml] = ACTIONS(99),
-    [anon_sym_body_COLONsparql] = ACTIONS(102),
-    [anon_sym_body_COLONgraphql] = ACTIONS(105),
-    [anon_sym_body_COLONgraphql_COLONvars] = ACTIONS(108),
-    [anon_sym_body_COLONform_DASHurlencoded] = ACTIONS(111),
-    [anon_sym_body_COLONmultipart_DASHform] = ACTIONS(114),
-    [anon_sym_vars] = ACTIONS(117),
-    [anon_sym_vars_COLONsecret] = ACTIONS(120),
-    [anon_sym_vars_COLONpre_DASHrequest] = ACTIONS(123),
-    [anon_sym_vars_COLONpost_DASHresponse] = ACTIONS(126),
-    [anon_sym_assert] = ACTIONS(129),
-    [anon_sym_script_COLONpre_DASHrequest] = ACTIONS(132),
-    [anon_sym_script_COLONpost_DASHresponse] = ACTIONS(135),
-    [anon_sym_tests] = ACTIONS(138),
-    [anon_sym_docs] = ACTIONS(141),
+    [ts_builtin_sym_end] = ACTIONS(63),
+    [anon_sym_meta] = ACTIONS(65),
+    [anon_sym_get] = ACTIONS(68),
+    [anon_sym_post] = ACTIONS(68),
+    [anon_sym_put] = ACTIONS(68),
+    [anon_sym_delete] = ACTIONS(68),
+    [anon_sym_patch] = ACTIONS(68),
+    [anon_sym_options] = ACTIONS(68),
+    [anon_sym_head] = ACTIONS(71),
+    [anon_sym_connect] = ACTIONS(68),
+    [anon_sym_trace] = ACTIONS(68),
+    [anon_sym_query] = ACTIONS(74),
+    [anon_sym_headers] = ACTIONS(77),
+    [anon_sym_auth_COLONawsv4] = ACTIONS(80),
+    [anon_sym_auth_COLONbasic] = ACTIONS(83),
+    [anon_sym_auth_COLONbearer] = ACTIONS(86),
+    [anon_sym_auth_COLONdigest] = ACTIONS(89),
+    [anon_sym_auth_COLONoauth2] = ACTIONS(92),
+    [anon_sym_body] = ACTIONS(95),
+    [anon_sym_body_COLONjson] = ACTIONS(98),
+    [anon_sym_body_COLONtext] = ACTIONS(101),
+    [anon_sym_body_COLONxml] = ACTIONS(104),
+    [anon_sym_body_COLONsparql] = ACTIONS(107),
+    [anon_sym_body_COLONgraphql] = ACTIONS(110),
+    [anon_sym_body_COLONgraphql_COLONvars] = ACTIONS(113),
+    [anon_sym_body_COLONform_DASHurlencoded] = ACTIONS(116),
+    [anon_sym_body_COLONmultipart_DASHform] = ACTIONS(119),
+    [anon_sym_vars] = ACTIONS(122),
+    [anon_sym_vars_COLONsecret] = ACTIONS(125),
+    [anon_sym_vars_COLONpre_DASHrequest] = ACTIONS(128),
+    [anon_sym_vars_COLONpost_DASHresponse] = ACTIONS(131),
+    [anon_sym_assert] = ACTIONS(134),
+    [anon_sym_script_COLONpre_DASHrequest] = ACTIONS(137),
+    [anon_sym_script_COLONpost_DASHresponse] = ACTIONS(140),
+    [anon_sym_tests] = ACTIONS(143),
+    [anon_sym_docs] = ACTIONS(146),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
   [0] = 2,
-    ACTIONS(146), 4,
+    ACTIONS(151), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(144), 31,
+    ACTIONS(149), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2003,6 +2028,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2018,13 +2044,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [40] = 2,
-    ACTIONS(150), 4,
+  [41] = 2,
+    ACTIONS(155), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(148), 31,
+    ACTIONS(153), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2041,6 +2067,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2056,13 +2083,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [80] = 2,
-    ACTIONS(154), 4,
+  [82] = 2,
+    ACTIONS(159), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(152), 31,
+    ACTIONS(157), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2079,6 +2106,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2094,13 +2122,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [120] = 2,
-    ACTIONS(158), 4,
+  [123] = 2,
+    ACTIONS(163), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(156), 31,
+    ACTIONS(161), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2117,6 +2145,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2132,13 +2161,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [160] = 2,
-    ACTIONS(162), 4,
+  [164] = 2,
+    ACTIONS(167), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(160), 31,
+    ACTIONS(165), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2155,6 +2184,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2170,13 +2200,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [200] = 2,
-    ACTIONS(166), 4,
+  [205] = 2,
+    ACTIONS(171), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(164), 31,
+    ACTIONS(169), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2193,6 +2223,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2208,13 +2239,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [240] = 2,
-    ACTIONS(170), 4,
+  [246] = 2,
+    ACTIONS(175), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(168), 31,
+    ACTIONS(173), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2231,6 +2262,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2246,13 +2278,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [280] = 2,
-    ACTIONS(174), 4,
+  [287] = 2,
+    ACTIONS(179), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(172), 31,
+    ACTIONS(177), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2269,6 +2301,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2284,13 +2317,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [320] = 2,
-    ACTIONS(178), 4,
+  [328] = 2,
+    ACTIONS(183), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(176), 31,
+    ACTIONS(181), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2307,6 +2340,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2322,13 +2356,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [360] = 2,
-    ACTIONS(182), 4,
+  [369] = 2,
+    ACTIONS(187), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(180), 31,
+    ACTIONS(185), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2345,6 +2379,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2360,13 +2395,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [400] = 2,
-    ACTIONS(186), 4,
+  [410] = 2,
+    ACTIONS(191), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(184), 31,
+    ACTIONS(189), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2383,6 +2418,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2398,13 +2434,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [440] = 2,
-    ACTIONS(190), 4,
+  [451] = 2,
+    ACTIONS(195), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(188), 31,
+    ACTIONS(193), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2421,6 +2457,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2436,13 +2473,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [480] = 2,
-    ACTIONS(194), 4,
+  [492] = 2,
+    ACTIONS(199), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(192), 31,
+    ACTIONS(197), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2459,6 +2496,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2474,13 +2512,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [520] = 2,
-    ACTIONS(198), 4,
+  [533] = 2,
+    ACTIONS(203), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(196), 31,
+    ACTIONS(201), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2497,6 +2535,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2512,13 +2551,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [560] = 2,
-    ACTIONS(202), 4,
+  [574] = 2,
+    ACTIONS(207), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(200), 31,
+    ACTIONS(205), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2535,6 +2574,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2550,13 +2590,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [600] = 2,
-    ACTIONS(206), 4,
+  [615] = 2,
+    ACTIONS(211), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(204), 31,
+    ACTIONS(209), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2573,6 +2613,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2588,13 +2629,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [640] = 2,
-    ACTIONS(210), 4,
+  [656] = 2,
+    ACTIONS(215), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(208), 31,
+    ACTIONS(213), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2611,6 +2652,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2626,13 +2668,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [680] = 2,
-    ACTIONS(214), 4,
+  [697] = 2,
+    ACTIONS(219), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(212), 31,
+    ACTIONS(217), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2649,6 +2691,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2664,13 +2707,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [720] = 2,
-    ACTIONS(218), 4,
+  [738] = 2,
+    ACTIONS(223), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(216), 31,
+    ACTIONS(221), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2687,6 +2730,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2702,13 +2746,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [760] = 2,
-    ACTIONS(222), 4,
+  [779] = 2,
+    ACTIONS(227), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(220), 31,
+    ACTIONS(225), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2725,6 +2769,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2740,13 +2785,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [800] = 2,
-    ACTIONS(226), 4,
+  [820] = 2,
+    ACTIONS(231), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(224), 31,
+    ACTIONS(229), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2763,6 +2808,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2778,13 +2824,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [840] = 2,
-    ACTIONS(230), 4,
+  [861] = 2,
+    ACTIONS(235), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(228), 31,
+    ACTIONS(233), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2801,6 +2847,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2816,13 +2863,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [880] = 2,
-    ACTIONS(234), 4,
+  [902] = 2,
+    ACTIONS(239), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(232), 31,
+    ACTIONS(237), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2839,6 +2886,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2854,13 +2902,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [920] = 2,
-    ACTIONS(238), 4,
+  [943] = 2,
+    ACTIONS(243), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(236), 31,
+    ACTIONS(241), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2877,6 +2925,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2892,13 +2941,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [960] = 2,
-    ACTIONS(242), 4,
+  [984] = 2,
+    ACTIONS(247), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(240), 31,
+    ACTIONS(245), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2915,6 +2964,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2930,13 +2980,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1000] = 2,
-    ACTIONS(246), 4,
+  [1025] = 2,
+    ACTIONS(251), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(244), 31,
+    ACTIONS(249), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2953,6 +3003,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -2968,13 +3019,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1040] = 2,
-    ACTIONS(250), 4,
+  [1066] = 2,
+    ACTIONS(255), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(248), 31,
+    ACTIONS(253), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -2991,6 +3042,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3006,13 +3058,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1080] = 2,
-    ACTIONS(254), 4,
+  [1107] = 2,
+    ACTIONS(259), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(252), 31,
+    ACTIONS(257), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3029,6 +3081,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3044,13 +3097,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1120] = 2,
-    ACTIONS(258), 4,
+  [1148] = 2,
+    ACTIONS(263), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(256), 31,
+    ACTIONS(261), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3067,6 +3120,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3082,13 +3136,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1160] = 2,
-    ACTIONS(262), 4,
+  [1189] = 2,
+    ACTIONS(267), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(260), 31,
+    ACTIONS(265), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3105,6 +3159,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3120,13 +3175,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1200] = 2,
-    ACTIONS(266), 4,
+  [1230] = 2,
+    ACTIONS(271), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(264), 31,
+    ACTIONS(269), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3143,6 +3198,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3158,13 +3214,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1240] = 2,
-    ACTIONS(270), 4,
+  [1271] = 2,
+    ACTIONS(275), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(268), 31,
+    ACTIONS(273), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3181,6 +3237,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3196,13 +3253,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1280] = 2,
-    ACTIONS(274), 4,
+  [1312] = 2,
+    ACTIONS(279), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(272), 31,
+    ACTIONS(277), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3219,6 +3276,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3234,13 +3292,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1320] = 2,
-    ACTIONS(278), 4,
+  [1353] = 2,
+    ACTIONS(283), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(276), 31,
+    ACTIONS(281), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3257,6 +3315,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3272,13 +3331,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1360] = 2,
-    ACTIONS(282), 4,
+  [1394] = 2,
+    ACTIONS(287), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(280), 31,
+    ACTIONS(285), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3295,6 +3354,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3310,13 +3370,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1400] = 2,
-    ACTIONS(286), 4,
+  [1435] = 2,
+    ACTIONS(291), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(284), 31,
+    ACTIONS(289), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3333,6 +3393,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3348,13 +3409,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1440] = 2,
-    ACTIONS(290), 4,
+  [1476] = 2,
+    ACTIONS(295), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(288), 31,
+    ACTIONS(293), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3371,6 +3432,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3386,13 +3448,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1480] = 2,
-    ACTIONS(294), 4,
+  [1517] = 2,
+    ACTIONS(299), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(292), 31,
+    ACTIONS(297), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3409,6 +3471,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3424,13 +3487,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1520] = 2,
-    ACTIONS(298), 4,
+  [1558] = 2,
+    ACTIONS(303), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(296), 31,
+    ACTIONS(301), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3447,6 +3510,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3462,13 +3526,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1560] = 2,
-    ACTIONS(302), 4,
+  [1599] = 2,
+    ACTIONS(307), 4,
       anon_sym_head,
       anon_sym_body,
       anon_sym_body_COLONgraphql,
       anon_sym_vars,
-    ACTIONS(300), 31,
+    ACTIONS(305), 32,
       ts_builtin_sym_end,
       anon_sym_meta,
       anon_sym_get,
@@ -3485,6 +3549,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_auth_COLONbasic,
       anon_sym_auth_COLONbearer,
       anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
       anon_sym_body_COLONjson,
       anon_sym_body_COLONtext,
       anon_sym_body_COLONxml,
@@ -3500,513 +3565,577 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_script_COLONpost_DASHresponse,
       anon_sym_tests,
       anon_sym_docs,
-  [1600] = 3,
-    ACTIONS(304), 1,
+  [1640] = 2,
+    ACTIONS(311), 4,
+      anon_sym_head,
+      anon_sym_body,
+      anon_sym_body_COLONgraphql,
+      anon_sym_vars,
+    ACTIONS(309), 32,
+      ts_builtin_sym_end,
+      anon_sym_meta,
+      anon_sym_get,
+      anon_sym_post,
+      anon_sym_put,
+      anon_sym_delete,
+      anon_sym_patch,
+      anon_sym_options,
+      anon_sym_connect,
+      anon_sym_trace,
+      anon_sym_query,
+      anon_sym_headers,
+      anon_sym_auth_COLONawsv4,
+      anon_sym_auth_COLONbasic,
+      anon_sym_auth_COLONbearer,
+      anon_sym_auth_COLONdigest,
+      anon_sym_auth_COLONoauth2,
+      anon_sym_body_COLONjson,
+      anon_sym_body_COLONtext,
+      anon_sym_body_COLONxml,
+      anon_sym_body_COLONsparql,
+      anon_sym_body_COLONgraphql_COLONvars,
+      anon_sym_body_COLONform_DASHurlencoded,
+      anon_sym_body_COLONmultipart_DASHform,
+      anon_sym_vars_COLONsecret,
+      anon_sym_vars_COLONpre_DASHrequest,
+      anon_sym_vars_COLONpost_DASHresponse,
+      anon_sym_assert,
+      anon_sym_script_COLONpre_DASHrequest,
+      anon_sym_script_COLONpost_DASHresponse,
+      anon_sym_tests,
+      anon_sym_docs,
+  [1681] = 3,
+    ACTIONS(313), 1,
       anon_sym_RBRACE,
-    ACTIONS(306), 1,
+    ACTIONS(315), 1,
       sym_key,
-    STATE(46), 2,
-      sym_dictionary_pair,
-      aux_sym_dictionary_repeat1,
-  [1611] = 3,
-    ACTIONS(308), 1,
-      anon_sym_RBRACE,
-    ACTIONS(310), 1,
-      sym_assert_key,
     STATE(47), 2,
-      sym_assert_dictionary_pair,
-      aux_sym_assert_dictionary_repeat1,
-  [1622] = 3,
-    ACTIONS(306), 1,
-      sym_key,
-    ACTIONS(312), 1,
-      anon_sym_RBRACE,
-    STATE(48), 2,
       sym_dictionary_pair,
       aux_sym_dictionary_repeat1,
-  [1633] = 3,
-    ACTIONS(310), 1,
+  [1692] = 3,
+    ACTIONS(317), 1,
+      anon_sym_RBRACE,
+    ACTIONS(319), 1,
       sym_assert_key,
-    ACTIONS(314), 1,
-      anon_sym_RBRACE,
-    STATE(49), 2,
+    STATE(48), 2,
       sym_assert_dictionary_pair,
       aux_sym_assert_dictionary_repeat1,
-  [1644] = 3,
-    ACTIONS(316), 1,
-      anon_sym_RBRACE,
-    ACTIONS(318), 1,
+  [1703] = 3,
+    ACTIONS(315), 1,
       sym_key,
-    STATE(48), 2,
-      sym_dictionary_pair,
-      aux_sym_dictionary_repeat1,
-  [1655] = 3,
     ACTIONS(321), 1,
       anon_sym_RBRACE,
-    ACTIONS(323), 1,
-      sym_assert_key,
     STATE(49), 2,
+      sym_dictionary_pair,
+      aux_sym_dictionary_repeat1,
+  [1714] = 3,
+    ACTIONS(319), 1,
+      sym_assert_key,
+    ACTIONS(323), 1,
+      anon_sym_RBRACE,
+    STATE(50), 2,
       sym_assert_dictionary_pair,
       aux_sym_assert_dictionary_repeat1,
-  [1666] = 3,
-    ACTIONS(326), 1,
-      anon_sym_RBRACK,
-    ACTIONS(328), 1,
-      sym_array_value,
-    STATE(52), 1,
-      aux_sym_array_repeat1,
-  [1676] = 2,
+  [1725] = 3,
+    ACTIONS(325), 1,
+      anon_sym_RBRACE,
+    ACTIONS(327), 1,
+      sym_key,
+    STATE(49), 2,
+      sym_dictionary_pair,
+      aux_sym_dictionary_repeat1,
+  [1736] = 3,
     ACTIONS(330), 1,
+      anon_sym_RBRACE,
+    ACTIONS(332), 1,
+      sym_assert_key,
+    STATE(50), 2,
+      sym_assert_dictionary_pair,
+      aux_sym_assert_dictionary_repeat1,
+  [1747] = 3,
+    ACTIONS(335), 1,
+      anon_sym_RBRACK,
+    ACTIONS(337), 1,
+      sym_array_value,
+    STATE(53), 1,
+      aux_sym_array_repeat1,
+  [1757] = 2,
+    ACTIONS(339), 1,
       anon_sym_COMMA,
-    ACTIONS(332), 2,
+    ACTIONS(341), 2,
       anon_sym_RBRACK,
       sym_array_value,
-  [1684] = 3,
-    ACTIONS(328), 1,
+  [1765] = 3,
+    ACTIONS(337), 1,
       sym_array_value,
-    ACTIONS(334), 1,
+    ACTIONS(343), 1,
       anon_sym_RBRACK,
-    STATE(53), 1,
+    STATE(54), 1,
       aux_sym_array_repeat1,
-  [1694] = 3,
-    ACTIONS(336), 1,
+  [1775] = 3,
+    ACTIONS(345), 1,
       anon_sym_RBRACK,
-    ACTIONS(338), 1,
+    ACTIONS(347), 1,
       sym_array_value,
-    STATE(53), 1,
+    STATE(54), 1,
       aux_sym_array_repeat1,
-  [1704] = 2,
-    ACTIONS(341), 1,
+  [1785] = 2,
+    ACTIONS(350), 1,
       anon_sym_LBRACE,
-    STATE(40), 1,
-      sym_dictionary,
-  [1711] = 2,
-    ACTIONS(341), 1,
+    STATE(22), 1,
+      sym_textblock,
+  [1792] = 2,
+    ACTIONS(352), 1,
       anon_sym_LBRACE,
     STATE(6), 1,
       sym_dictionary,
-  [1718] = 2,
-    ACTIONS(341), 1,
+  [1799] = 2,
+    ACTIONS(352), 1,
       anon_sym_LBRACE,
     STATE(41), 1,
       sym_dictionary,
-  [1725] = 2,
-    ACTIONS(343), 1,
-      anon_sym_RBRACE,
-    ACTIONS(345), 1,
-      sym_rawtext,
-  [1732] = 2,
-    ACTIONS(341), 1,
-      anon_sym_LBRACE,
-    STATE(38), 1,
-      sym_dictionary,
-  [1739] = 2,
-    ACTIONS(341), 1,
-      anon_sym_LBRACE,
-    STATE(22), 1,
-      sym_dictionary,
-  [1746] = 1,
-    ACTIONS(347), 2,
-      anon_sym_RBRACE,
-      sym_assert_key,
-  [1751] = 2,
-    ACTIONS(349), 1,
-      anon_sym_LBRACE,
-    STATE(4), 1,
-      sym_textblock,
-  [1758] = 2,
-    ACTIONS(349), 1,
-      anon_sym_LBRACE,
-    STATE(23), 1,
-      sym_textblock,
-  [1765] = 2,
-    ACTIONS(349), 1,
-      anon_sym_LBRACE,
-    STATE(24), 1,
-      sym_textblock,
-  [1772] = 2,
-    ACTIONS(349), 1,
-      anon_sym_LBRACE,
-    STATE(25), 1,
-      sym_textblock,
-  [1779] = 2,
-    ACTIONS(341), 1,
-      anon_sym_LBRACE,
-    STATE(39), 1,
-      sym_dictionary,
-  [1786] = 2,
-    ACTIONS(351), 1,
-      anon_sym_LBRACE,
-    STATE(26), 1,
-      sym_assert_dictionary,
-  [1793] = 1,
-    ACTIONS(353), 2,
-      anon_sym_RBRACE,
-      sym_key,
-  [1798] = 2,
-    ACTIONS(341), 1,
-      anon_sym_LBRACE,
-    STATE(28), 1,
-      sym_dictionary,
-  [1805] = 2,
-    ACTIONS(341), 1,
+  [1806] = 2,
+    ACTIONS(352), 1,
       anon_sym_LBRACE,
     STATE(42), 1,
       sym_dictionary,
-  [1812] = 2,
-    ACTIONS(355), 1,
-      anon_sym_LBRACK,
-    STATE(36), 1,
-      sym_array,
-  [1819] = 2,
-    ACTIONS(341), 1,
+  [1813] = 2,
+    ACTIONS(354), 1,
+      anon_sym_RBRACE,
+    ACTIONS(356), 1,
+      sym_rawtext,
+  [1820] = 2,
+    ACTIONS(352), 1,
       anon_sym_LBRACE,
-    STATE(43), 1,
+    STATE(39), 1,
       sym_dictionary,
-  [1826] = 2,
-    ACTIONS(341), 1,
+  [1827] = 2,
+    ACTIONS(352), 1,
       anon_sym_LBRACE,
-    STATE(29), 1,
+    STATE(4), 1,
       sym_dictionary,
-  [1833] = 2,
-    ACTIONS(341), 1,
-      anon_sym_LBRACE,
-    STATE(30), 1,
-      sym_dictionary,
-  [1840] = 2,
-    ACTIONS(341), 1,
-      anon_sym_LBRACE,
-    STATE(8), 1,
-      sym_dictionary,
-  [1847] = 2,
-    ACTIONS(349), 1,
-      anon_sym_LBRACE,
-    STATE(11), 1,
-      sym_textblock,
-  [1854] = 2,
-    ACTIONS(349), 1,
-      anon_sym_LBRACE,
-    STATE(13), 1,
-      sym_textblock,
-  [1861] = 2,
-    ACTIONS(341), 1,
-      anon_sym_LBRACE,
-    STATE(19), 1,
-      sym_dictionary,
-  [1868] = 2,
-    ACTIONS(349), 1,
-      anon_sym_LBRACE,
-    STATE(15), 1,
-      sym_textblock,
-  [1875] = 2,
-    ACTIONS(349), 1,
-      anon_sym_LBRACE,
-    STATE(27), 1,
-      sym_textblock,
-  [1882] = 2,
-    ACTIONS(349), 1,
-      anon_sym_LBRACE,
-    STATE(16), 1,
-      sym_textblock,
-  [1889] = 2,
-    ACTIONS(349), 1,
+  [1834] = 2,
+    ACTIONS(350), 1,
       anon_sym_LBRACE,
     STATE(21), 1,
       sym_textblock,
-  [1896] = 2,
-    ACTIONS(349), 1,
+  [1841] = 2,
+    ACTIONS(350), 1,
       anon_sym_LBRACE,
-    STATE(37), 1,
+    STATE(23), 1,
       sym_textblock,
-  [1903] = 1,
-    ACTIONS(336), 2,
+  [1848] = 2,
+    ACTIONS(350), 1,
+      anon_sym_LBRACE,
+    STATE(24), 1,
+      sym_textblock,
+  [1855] = 2,
+    ACTIONS(358), 1,
+      anon_sym_LBRACE,
+    STATE(25), 1,
+      sym_assert_dictionary,
+  [1862] = 2,
+    ACTIONS(352), 1,
+      anon_sym_LBRACE,
+    STATE(28), 1,
+      sym_dictionary,
+  [1869] = 2,
+    ACTIONS(352), 1,
+      anon_sym_LBRACE,
+    STATE(31), 1,
+      sym_dictionary,
+  [1876] = 2,
+    ACTIONS(352), 1,
+      anon_sym_LBRACE,
+    STATE(40), 1,
+      sym_dictionary,
+  [1883] = 1,
+    ACTIONS(360), 2,
+      anon_sym_RBRACE,
+      sym_assert_key,
+  [1888] = 2,
+    ACTIONS(362), 1,
+      anon_sym_LBRACK,
+    STATE(37), 1,
+      sym_array,
+  [1895] = 1,
+    ACTIONS(364), 2,
+      anon_sym_RBRACE,
+      sym_key,
+  [1900] = 2,
+    ACTIONS(352), 1,
+      anon_sym_LBRACE,
+    STATE(29), 1,
+      sym_dictionary,
+  [1907] = 2,
+    ACTIONS(352), 1,
+      anon_sym_LBRACE,
+    STATE(43), 1,
+      sym_dictionary,
+  [1914] = 2,
+    ACTIONS(352), 1,
+      anon_sym_LBRACE,
+    STATE(44), 1,
+      sym_dictionary,
+  [1921] = 2,
+    ACTIONS(352), 1,
+      anon_sym_LBRACE,
+    STATE(8), 1,
+      sym_dictionary,
+  [1928] = 2,
+    ACTIONS(350), 1,
+      anon_sym_LBRACE,
+    STATE(11), 1,
+      sym_textblock,
+  [1935] = 2,
+    ACTIONS(350), 1,
+      anon_sym_LBRACE,
+    STATE(13), 1,
+      sym_textblock,
+  [1942] = 2,
+    ACTIONS(350), 1,
+      anon_sym_LBRACE,
+    STATE(15), 1,
+      sym_textblock,
+  [1949] = 2,
+    ACTIONS(352), 1,
+      anon_sym_LBRACE,
+    STATE(38), 1,
+      sym_dictionary,
+  [1956] = 2,
+    ACTIONS(350), 1,
+      anon_sym_LBRACE,
+    STATE(16), 1,
+      sym_textblock,
+  [1963] = 2,
+    ACTIONS(352), 1,
+      anon_sym_LBRACE,
+    STATE(26), 1,
+      sym_dictionary,
+  [1970] = 2,
+    ACTIONS(350), 1,
+      anon_sym_LBRACE,
+    STATE(5), 1,
+      sym_textblock,
+  [1977] = 2,
+    ACTIONS(350), 1,
+      anon_sym_LBRACE,
+    STATE(33), 1,
+      sym_textblock,
+  [1984] = 2,
+    ACTIONS(350), 1,
+      anon_sym_LBRACE,
+    STATE(27), 1,
+      sym_textblock,
+  [1991] = 1,
+    ACTIONS(345), 2,
       anon_sym_RBRACK,
       sym_array_value,
-  [1908] = 1,
-    ACTIONS(357), 1,
+  [1996] = 1,
+    ACTIONS(366), 1,
       sym_value,
-  [1912] = 1,
-    ACTIONS(359), 1,
+  [2000] = 1,
+    ACTIONS(368), 1,
       anon_sym_COLON,
-  [1916] = 1,
-    ACTIONS(361), 1,
+  [2004] = 1,
+    ACTIONS(370), 1,
       sym_value,
-  [1920] = 1,
-    ACTIONS(363), 1,
-      anon_sym_RBRACE,
-  [1924] = 1,
-    ACTIONS(365), 1,
-      anon_sym_COLON,
-  [1928] = 1,
-    ACTIONS(367), 1,
-      anon_sym_LBRACE,
-  [1932] = 1,
-    ACTIONS(369), 1,
+  [2008] = 1,
+    ACTIONS(372), 1,
       ts_builtin_sym_end,
+  [2012] = 1,
+    ACTIONS(374), 1,
+      anon_sym_RBRACE,
+  [2016] = 1,
+    ACTIONS(376), 1,
+      anon_sym_COLON,
+  [2020] = 1,
+    ACTIONS(378), 1,
+      anon_sym_LBRACE,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(4)] = 0,
-  [SMALL_STATE(5)] = 40,
-  [SMALL_STATE(6)] = 80,
-  [SMALL_STATE(7)] = 120,
-  [SMALL_STATE(8)] = 160,
-  [SMALL_STATE(9)] = 200,
-  [SMALL_STATE(10)] = 240,
-  [SMALL_STATE(11)] = 280,
-  [SMALL_STATE(12)] = 320,
-  [SMALL_STATE(13)] = 360,
-  [SMALL_STATE(14)] = 400,
-  [SMALL_STATE(15)] = 440,
-  [SMALL_STATE(16)] = 480,
-  [SMALL_STATE(17)] = 520,
-  [SMALL_STATE(18)] = 560,
-  [SMALL_STATE(19)] = 600,
-  [SMALL_STATE(20)] = 640,
-  [SMALL_STATE(21)] = 680,
-  [SMALL_STATE(22)] = 720,
-  [SMALL_STATE(23)] = 760,
-  [SMALL_STATE(24)] = 800,
-  [SMALL_STATE(25)] = 840,
-  [SMALL_STATE(26)] = 880,
-  [SMALL_STATE(27)] = 920,
-  [SMALL_STATE(28)] = 960,
-  [SMALL_STATE(29)] = 1000,
-  [SMALL_STATE(30)] = 1040,
-  [SMALL_STATE(31)] = 1080,
-  [SMALL_STATE(32)] = 1120,
-  [SMALL_STATE(33)] = 1160,
-  [SMALL_STATE(34)] = 1200,
-  [SMALL_STATE(35)] = 1240,
-  [SMALL_STATE(36)] = 1280,
-  [SMALL_STATE(37)] = 1320,
-  [SMALL_STATE(38)] = 1360,
-  [SMALL_STATE(39)] = 1400,
-  [SMALL_STATE(40)] = 1440,
-  [SMALL_STATE(41)] = 1480,
-  [SMALL_STATE(42)] = 1520,
-  [SMALL_STATE(43)] = 1560,
-  [SMALL_STATE(44)] = 1600,
-  [SMALL_STATE(45)] = 1611,
-  [SMALL_STATE(46)] = 1622,
-  [SMALL_STATE(47)] = 1633,
-  [SMALL_STATE(48)] = 1644,
-  [SMALL_STATE(49)] = 1655,
-  [SMALL_STATE(50)] = 1666,
-  [SMALL_STATE(51)] = 1676,
-  [SMALL_STATE(52)] = 1684,
-  [SMALL_STATE(53)] = 1694,
-  [SMALL_STATE(54)] = 1704,
-  [SMALL_STATE(55)] = 1711,
-  [SMALL_STATE(56)] = 1718,
-  [SMALL_STATE(57)] = 1725,
-  [SMALL_STATE(58)] = 1732,
-  [SMALL_STATE(59)] = 1739,
-  [SMALL_STATE(60)] = 1746,
-  [SMALL_STATE(61)] = 1751,
-  [SMALL_STATE(62)] = 1758,
-  [SMALL_STATE(63)] = 1765,
-  [SMALL_STATE(64)] = 1772,
-  [SMALL_STATE(65)] = 1779,
-  [SMALL_STATE(66)] = 1786,
-  [SMALL_STATE(67)] = 1793,
-  [SMALL_STATE(68)] = 1798,
-  [SMALL_STATE(69)] = 1805,
-  [SMALL_STATE(70)] = 1812,
-  [SMALL_STATE(71)] = 1819,
-  [SMALL_STATE(72)] = 1826,
-  [SMALL_STATE(73)] = 1833,
-  [SMALL_STATE(74)] = 1840,
-  [SMALL_STATE(75)] = 1847,
-  [SMALL_STATE(76)] = 1854,
-  [SMALL_STATE(77)] = 1861,
-  [SMALL_STATE(78)] = 1868,
-  [SMALL_STATE(79)] = 1875,
-  [SMALL_STATE(80)] = 1882,
-  [SMALL_STATE(81)] = 1889,
-  [SMALL_STATE(82)] = 1896,
-  [SMALL_STATE(83)] = 1903,
-  [SMALL_STATE(84)] = 1908,
-  [SMALL_STATE(85)] = 1912,
-  [SMALL_STATE(86)] = 1916,
-  [SMALL_STATE(87)] = 1920,
-  [SMALL_STATE(88)] = 1924,
-  [SMALL_STATE(89)] = 1928,
-  [SMALL_STATE(90)] = 1932,
+  [SMALL_STATE(5)] = 41,
+  [SMALL_STATE(6)] = 82,
+  [SMALL_STATE(7)] = 123,
+  [SMALL_STATE(8)] = 164,
+  [SMALL_STATE(9)] = 205,
+  [SMALL_STATE(10)] = 246,
+  [SMALL_STATE(11)] = 287,
+  [SMALL_STATE(12)] = 328,
+  [SMALL_STATE(13)] = 369,
+  [SMALL_STATE(14)] = 410,
+  [SMALL_STATE(15)] = 451,
+  [SMALL_STATE(16)] = 492,
+  [SMALL_STATE(17)] = 533,
+  [SMALL_STATE(18)] = 574,
+  [SMALL_STATE(19)] = 615,
+  [SMALL_STATE(20)] = 656,
+  [SMALL_STATE(21)] = 697,
+  [SMALL_STATE(22)] = 738,
+  [SMALL_STATE(23)] = 779,
+  [SMALL_STATE(24)] = 820,
+  [SMALL_STATE(25)] = 861,
+  [SMALL_STATE(26)] = 902,
+  [SMALL_STATE(27)] = 943,
+  [SMALL_STATE(28)] = 984,
+  [SMALL_STATE(29)] = 1025,
+  [SMALL_STATE(30)] = 1066,
+  [SMALL_STATE(31)] = 1107,
+  [SMALL_STATE(32)] = 1148,
+  [SMALL_STATE(33)] = 1189,
+  [SMALL_STATE(34)] = 1230,
+  [SMALL_STATE(35)] = 1271,
+  [SMALL_STATE(36)] = 1312,
+  [SMALL_STATE(37)] = 1353,
+  [SMALL_STATE(38)] = 1394,
+  [SMALL_STATE(39)] = 1435,
+  [SMALL_STATE(40)] = 1476,
+  [SMALL_STATE(41)] = 1517,
+  [SMALL_STATE(42)] = 1558,
+  [SMALL_STATE(43)] = 1599,
+  [SMALL_STATE(44)] = 1640,
+  [SMALL_STATE(45)] = 1681,
+  [SMALL_STATE(46)] = 1692,
+  [SMALL_STATE(47)] = 1703,
+  [SMALL_STATE(48)] = 1714,
+  [SMALL_STATE(49)] = 1725,
+  [SMALL_STATE(50)] = 1736,
+  [SMALL_STATE(51)] = 1747,
+  [SMALL_STATE(52)] = 1757,
+  [SMALL_STATE(53)] = 1765,
+  [SMALL_STATE(54)] = 1775,
+  [SMALL_STATE(55)] = 1785,
+  [SMALL_STATE(56)] = 1792,
+  [SMALL_STATE(57)] = 1799,
+  [SMALL_STATE(58)] = 1806,
+  [SMALL_STATE(59)] = 1813,
+  [SMALL_STATE(60)] = 1820,
+  [SMALL_STATE(61)] = 1827,
+  [SMALL_STATE(62)] = 1834,
+  [SMALL_STATE(63)] = 1841,
+  [SMALL_STATE(64)] = 1848,
+  [SMALL_STATE(65)] = 1855,
+  [SMALL_STATE(66)] = 1862,
+  [SMALL_STATE(67)] = 1869,
+  [SMALL_STATE(68)] = 1876,
+  [SMALL_STATE(69)] = 1883,
+  [SMALL_STATE(70)] = 1888,
+  [SMALL_STATE(71)] = 1895,
+  [SMALL_STATE(72)] = 1900,
+  [SMALL_STATE(73)] = 1907,
+  [SMALL_STATE(74)] = 1914,
+  [SMALL_STATE(75)] = 1921,
+  [SMALL_STATE(76)] = 1928,
+  [SMALL_STATE(77)] = 1935,
+  [SMALL_STATE(78)] = 1942,
+  [SMALL_STATE(79)] = 1949,
+  [SMALL_STATE(80)] = 1956,
+  [SMALL_STATE(81)] = 1963,
+  [SMALL_STATE(82)] = 1970,
+  [SMALL_STATE(83)] = 1977,
+  [SMALL_STATE(84)] = 1984,
+  [SMALL_STATE(85)] = 1991,
+  [SMALL_STATE(86)] = 1996,
+  [SMALL_STATE(87)] = 2000,
+  [SMALL_STATE(88)] = 2004,
+  [SMALL_STATE(89)] = 2008,
+  [SMALL_STATE(90)] = 2012,
+  [SMALL_STATE(91)] = 2016,
+  [SMALL_STATE(92)] = 2020,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(89),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(92),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(84),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
   [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, .production_id = 2),
-  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3),
-  [63] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(58),
-  [66] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(89),
-  [69] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(89),
-  [72] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(65),
-  [75] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(54),
-  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(56),
-  [81] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(69),
-  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(71),
-  [87] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(77),
-  [90] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(79),
-  [93] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(82),
-  [96] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(81),
-  [99] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(80),
-  [102] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(78),
-  [105] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(76),
-  [108] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(75),
-  [111] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(74),
-  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(55),
-  [117] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(72),
-  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(70),
-  [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(73),
-  [126] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(68),
-  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(66),
-  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(64),
-  [135] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(63),
-  [138] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(62),
-  [141] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(61),
-  [144] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_docs, 2),
-  [146] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_docs, 2),
-  [148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 1, .production_id = 1),
-  [150] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 1, .production_id = 1),
-  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyformmultipart, 2),
-  [154] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyformmultipart, 2),
-  [156] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assert_dictionary, 3),
-  [158] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert_dictionary, 3),
-  [160] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyformurlencoded, 2),
-  [162] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyformurlencoded, 2),
-  [164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
-  [166] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
-  [168] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_textblock, 3),
-  [170] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_textblock, 3),
-  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodygraphqlvars, 2),
-  [174] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodygraphqlvars, 2),
-  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary, 3),
-  [178] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary, 3),
-  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodygraphql, 2),
-  [182] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodygraphql, 2),
-  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assert_dictionary, 2),
-  [186] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert_dictionary, 2),
-  [188] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodysparql, 2),
-  [190] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodysparql, 2),
-  [192] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyxml, 2),
-  [194] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyxml, 2),
-  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 2),
-  [198] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 2),
-  [200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_textblock, 2),
-  [202] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_textblock, 2),
-  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authdigest, 2),
-  [206] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_authdigest, 2),
-  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary, 2),
-  [210] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary, 2),
-  [212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodytext, 2),
-  [214] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodytext, 2),
-  [216] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_http, 2),
-  [218] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_http, 2),
-  [220] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tests, 2),
-  [222] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tests, 2),
-  [224] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scriptres, 2),
-  [226] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scriptres, 2),
-  [228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scriptreq, 2),
-  [230] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scriptreq, 2),
-  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assert, 2),
-  [234] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert, 2),
-  [236] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_body, 2),
-  [238] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_body, 2),
-  [240] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_varsres, 2),
-  [242] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_varsres, 2),
-  [244] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_vars, 2),
-  [246] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_vars, 2),
-  [248] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_varsreq, 2),
-  [250] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_varsreq, 2),
-  [252] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_auths, 1),
-  [254] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_auths, 1),
-  [256] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodies, 1),
-  [258] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodies, 1),
-  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyforms, 1),
-  [262] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyforms, 1),
-  [264] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_varsandassert, 1),
-  [266] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_varsandassert, 1),
-  [268] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script, 1),
-  [270] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_script, 1),
-  [272] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_vars_secret, 2),
-  [274] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_vars_secret, 2),
-  [276] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyjson, 2),
-  [278] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyjson, 2),
-  [280] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2),
-  [282] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_meta, 2),
-  [284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query, 2),
-  [286] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query, 2),
-  [288] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_headers, 2),
-  [290] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_headers, 2),
-  [292] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authawsv4, 2),
-  [294] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_authawsv4, 2),
-  [296] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authbasic, 2),
-  [298] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_authbasic, 2),
-  [300] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authbearer, 2),
-  [302] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_authbearer, 2),
-  [304] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [306] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
-  [308] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
-  [310] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
-  [312] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
-  [314] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_dictionary_repeat1, 2),
-  [318] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_dictionary_repeat1, 2), SHIFT_REPEAT(88),
-  [321] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_assert_dictionary_repeat1, 2),
-  [323] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_assert_dictionary_repeat1, 2), SHIFT_REPEAT(85),
-  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [330] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [332] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 1),
-  [334] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [336] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
-  [338] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(51),
-  [341] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [343] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [345] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [347] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert_dictionary_pair, 3),
-  [349] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [351] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [353] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_pair, 3),
-  [355] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [359] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [361] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [363] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [365] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [367] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_http_verb, 1),
-  [369] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, .production_id = 2),
+  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3),
+  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(60),
+  [68] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(92),
+  [71] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(92),
+  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(68),
+  [77] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(57),
+  [80] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(58),
+  [83] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(73),
+  [86] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(74),
+  [89] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(79),
+  [92] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(81),
+  [95] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(84),
+  [98] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(83),
+  [101] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(82),
+  [104] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(80),
+  [107] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(78),
+  [110] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(77),
+  [113] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(76),
+  [116] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(75),
+  [119] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(56),
+  [122] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(72),
+  [125] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(70),
+  [128] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(67),
+  [131] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(66),
+  [134] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(65),
+  [137] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(64),
+  [140] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(63),
+  [143] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(55),
+  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, .production_id = 3), SHIFT_REPEAT(62),
+  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_http, 2),
+  [151] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_http, 2),
+  [153] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodytext, 2),
+  [155] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodytext, 2),
+  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyformmultipart, 2),
+  [159] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyformmultipart, 2),
+  [161] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assert_dictionary, 3),
+  [163] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert_dictionary, 3),
+  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyformurlencoded, 2),
+  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyformurlencoded, 2),
+  [169] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
+  [171] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
+  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_textblock, 3),
+  [175] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_textblock, 3),
+  [177] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodygraphqlvars, 2),
+  [179] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodygraphqlvars, 2),
+  [181] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary, 3),
+  [183] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary, 3),
+  [185] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodygraphql, 2),
+  [187] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodygraphql, 2),
+  [189] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assert_dictionary, 2),
+  [191] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert_dictionary, 2),
+  [193] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodysparql, 2),
+  [195] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodysparql, 2),
+  [197] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyxml, 2),
+  [199] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyxml, 2),
+  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 2),
+  [203] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 2),
+  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_textblock, 2),
+  [207] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_textblock, 2),
+  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodies, 1),
+  [211] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodies, 1),
+  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary, 2),
+  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary, 2),
+  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_docs, 2),
+  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_docs, 2),
+  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tests, 2),
+  [223] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tests, 2),
+  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scriptres, 2),
+  [227] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scriptres, 2),
+  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scriptreq, 2),
+  [231] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scriptreq, 2),
+  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assert, 2),
+  [235] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert, 2),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authoauth2, 2),
+  [239] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_authoauth2, 2),
+  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_body, 2),
+  [243] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_body, 2),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_varsres, 2),
+  [247] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_varsres, 2),
+  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_vars, 2),
+  [251] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_vars, 2),
+  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 1, .production_id = 1),
+  [255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 1, .production_id = 1),
+  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_varsreq, 2),
+  [259] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_varsreq, 2),
+  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_auths, 1),
+  [263] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_auths, 1),
+  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyjson, 2),
+  [267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyjson, 2),
+  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_bodyforms, 1),
+  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_bodyforms, 1),
+  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_varsandassert, 1),
+  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_varsandassert, 1),
+  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script, 1),
+  [279] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_script, 1),
+  [281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_vars_secret, 2),
+  [283] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_vars_secret, 2),
+  [285] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authdigest, 2),
+  [287] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_authdigest, 2),
+  [289] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2),
+  [291] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_meta, 2),
+  [293] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query, 2),
+  [295] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query, 2),
+  [297] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_headers, 2),
+  [299] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_headers, 2),
+  [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authawsv4, 2),
+  [303] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_authawsv4, 2),
+  [305] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authbasic, 2),
+  [307] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_authbasic, 2),
+  [309] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authbearer, 2),
+  [311] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_authbearer, 2),
+  [313] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [315] = {.entry = {.count = 1, .reusable = false}}, SHIFT(91),
+  [317] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [319] = {.entry = {.count = 1, .reusable = false}}, SHIFT(87),
+  [321] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [323] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
+  [325] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_dictionary_repeat1, 2),
+  [327] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_dictionary_repeat1, 2), SHIFT_REPEAT(91),
+  [330] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_assert_dictionary_repeat1, 2),
+  [332] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_assert_dictionary_repeat1, 2), SHIFT_REPEAT(87),
+  [335] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [337] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [339] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [341] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 1),
+  [343] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [345] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
+  [347] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(52),
+  [350] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [352] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [354] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [356] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [358] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [360] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_assert_dictionary_pair, 3),
+  [362] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [364] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_pair, 3),
+  [366] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [368] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [370] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [372] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [374] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [376] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [378] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_http_verb, 1),
+};
+
+enum ts_external_scanner_symbol_identifiers {
+  ts_external_token_rawtext = 0,
+};
+
+static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
+  [ts_external_token_rawtext] = sym_rawtext,
+};
+
+static const bool ts_external_scanner_states[2][EXTERNAL_TOKEN_COUNT] = {
+  [1] = {
+    [ts_external_token_rawtext] = true,
+  },
 };
 
 #ifdef __cplusplus
@@ -4018,11 +4147,17 @@ bool tree_sitter_bruno_external_scanner_scan(void *, TSLexer *, const bool *);
 unsigned tree_sitter_bruno_external_scanner_serialize(void *, char *);
 void tree_sitter_bruno_external_scanner_deserialize(void *, const char *, unsigned);
 
-#ifdef _WIN32
-#define extern __declspec(dllexport)
+#ifdef TS_PUBLIC
+#undef TS_PUBLIC
 #endif
 
-extern const TSLanguage *tree_sitter_bruno(void) {
+#ifdef _WIN32
+#define TS_PUBLIC
+#else
+#define TS_PUBLIC __attribute__((visibility("default")))
+#endif
+
+TS_PUBLIC const TSLanguage *tree_sitter_bruno() {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -130,9 +129,16 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -166,7 +172,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +182,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +190,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}

--- a/test/corpus/auth.txt
+++ b/test/corpus/auth.txt
@@ -1,0 +1,28 @@
+===========
+Auth Oauth2
+===========
+
+auth:oauth2 {
+  grant_type: authorization_code
+  scope: read write
+}
+
+---
+
+(source_file
+  (auths
+    (authoauth2
+      (keyword)
+      (dictionary
+        (dictionary_pair
+          (key)
+          (value)
+        )
+        (dictionary_pair
+          (key)
+          (value)
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
Hello,

Thanks for creating this tree-sitter parser for Bruno!

I noted that there's no support for the [`auth:oauth2` tag](https://github.com/usebruno/bruno/blob/5f35d71b8ba5d8cb287ae5897cd4a6310006fe90/packages/bruno-lang/v2/src/bruToJson.js#L83) and thought it seemed like a good time to try to modify a tree-sitter parser. Which I've never done before so feel free to state I've done something crazy. But it appears to work!